### PR TITLE
Fix sitemap for migrated public paths

### DIFF
--- a/e2e/specs/public/sitemap.spec.ts
+++ b/e2e/specs/public/sitemap.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect } from "../../fixtures/worker";
+import {
+	createAndPublishContentViaApi,
+	uniqueTitle,
+} from "../../support/content";
+
+function parseLocations(xml: string) {
+	return [...xml.matchAll(/<loc>\s*([^<]+?)\s*<\/loc>/g)].map(
+		(match) => match[1] ?? "",
+	);
+}
+
+function parseLocationPaths(xml: string) {
+	return parseLocations(xml).map((location) => {
+		try {
+			return new URL(location).pathname;
+		} catch {
+			throw new Error(`Invalid sitemap URL: ${location}`);
+		}
+	});
+}
+
+test.describe("public sitemap", () => {
+	test("lists published content at public WordPress-compatible paths", async ({
+		authedRequest,
+		publicPage,
+	}, testInfo) => {
+		const pageTitle = uniqueTitle("E2E Sitemap Page", testInfo.testId);
+		const postTitle = uniqueTitle("E2E Sitemap Post", testInfo.testId);
+		const postSlug = `e2e-sitemap-${testInfo.testId}`
+			.toLowerCase()
+			.replace(/[^a-z0-9]+/g, "-")
+			.replace(/^-+|-+$/g, "")
+			.slice(0, 48);
+		const publishedAt = "2022-05-31T12:00:00Z";
+
+		const { publicPath: pagePath } = await createAndPublishContentViaApi(
+			authedRequest,
+			"pages",
+			{
+				title: pageTitle,
+			},
+		);
+		const { publicPath: postPath } = await createAndPublishContentViaApi(
+			authedRequest,
+			"posts",
+			{
+				title: postTitle,
+				slug: postSlug,
+				publishedAt,
+			},
+		);
+
+		const response = await publicPage.goto("/sitemap.xml");
+		expect(response?.status()).toBe(200);
+		expect(response?.headers()["content-type"]).toContain("application/xml");
+
+		const xml = await response!.text();
+		const locationPaths = parseLocationPaths(xml);
+
+		expect(locationPaths).toContain(pagePath);
+		expect(locationPaths).toContain(postPath);
+		expect(locationPaths).not.toContain(`/posts/${postSlug}/`);
+		expect(xml).toContain("<urlset");
+	});
+});

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
 		"test:e2e:headed": "playwright test --headed",
 		"test:e2e:ui": "playwright test --ui",
 		"smoke:live": "node scripts/test-smoke-live.mjs",
-		"smoke:live:sitemap": "LIVE_SMOKE_SITEMAP=1 node scripts/test-smoke-live.mjs",
+		"smoke:live:sitemap": "LIVE_SMOKE_SITEMAP=1 LIVE_SMOKE_REQUIRE_SITEMAP=1 node scripts/test-smoke-live.mjs",
 		"smoke:live:wordpress": "LIVE_SMOKE_WORDPRESS_EXPORT=engagedphilosophy.WordPress.2026-05-25.xml node scripts/test-smoke-live.mjs",
 		"preview": "astro preview",
 		"deploy": "pnpm run build && wrangler deploy",

--- a/src/lib/sitemap.ts
+++ b/src/lib/sitemap.ts
@@ -1,0 +1,110 @@
+const AMP_RE = /&/g;
+const LT_RE = /</g;
+const GT_RE = />/g;
+const QUOT_RE = /"/g;
+const APOS_RE = /'/g;
+
+export interface SitemapInputEntry {
+	id: string;
+	updated_at?: string | null;
+	updatedAt?: string | Date | null;
+	published_at?: string | null;
+	publishedAt?: string | Date | null;
+	createdAt?: string | Date | null;
+	data: {
+		path?: string | null;
+		updated_at?: string | null;
+		updatedAt?: string | Date | null;
+		published_at?: string | null;
+		publishedAt?: string | Date | null;
+		published_on?: string | null;
+	};
+}
+
+export function canonicalSitemapOrigin(origin: string) {
+	return origin.replace(/\/+$/, "");
+}
+
+export function sitemapPathToUrl(origin: string, path?: string | null) {
+	const normalizedPath = (path ?? "").trim().replace(/^\/+|\/+$/g, "");
+	const pathname = normalizedPath ? `/${normalizedPath}/` : "/";
+	return `${canonicalSitemapOrigin(origin)}${pathname}`;
+}
+
+function timestampValue(value?: string | Date | null) {
+	if (!value) return "";
+	return value instanceof Date ? value.toISOString() : value;
+}
+
+export function sitemapEntryLastmod(entry: SitemapInputEntry) {
+	return (
+		timestampValue(entry.updated_at) ||
+		timestampValue(entry.updatedAt) ||
+		timestampValue(entry.data.updated_at) ||
+		timestampValue(entry.data.updatedAt) ||
+		timestampValue(entry.published_at) ||
+		timestampValue(entry.publishedAt) ||
+		timestampValue(entry.data.published_at) ||
+		timestampValue(entry.data.publishedAt) ||
+		timestampValue(entry.data.published_on) ||
+		timestampValue(entry.createdAt)
+	);
+}
+
+function timestampMillis(value: string) {
+	const millis = Date.parse(value);
+	return Number.isNaN(millis) ? null : millis;
+}
+
+function newerLastmod(current: string, next: string) {
+	if (!current) return next;
+	if (!next) return current;
+
+	const currentMillis = timestampMillis(current);
+	const nextMillis = timestampMillis(next);
+	if (currentMillis !== null && nextMillis !== null) {
+		return nextMillis > currentMillis ? next : current;
+	}
+	if (currentMillis === null && nextMillis !== null) return next;
+	if (currentMillis !== null && nextMillis === null) return current;
+	return next > current ? next : current;
+}
+
+export function escapeSitemapXml(value: string) {
+	return value
+		.replace(AMP_RE, "&amp;")
+		.replace(LT_RE, "&lt;")
+		.replace(GT_RE, "&gt;")
+		.replace(QUOT_RE, "&quot;")
+		.replace(APOS_RE, "&apos;");
+}
+
+export function renderSitemapXml(origin: string, entries: SitemapInputEntry[]) {
+	const urls = new Map<string, string>();
+	const lines = [
+		'<?xml version="1.0" encoding="UTF-8"?>',
+		'<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+	];
+
+	for (const entry of entries) {
+		const loc = sitemapPathToUrl(origin, entry.data.path);
+		urls.set(
+			loc,
+			newerLastmod(urls.get(loc) ?? "", sitemapEntryLastmod(entry)),
+		);
+	}
+
+	for (const [loc, lastmod] of urls) {
+		lines.push("  <url>");
+		lines.push(`    <loc>${escapeSitemapXml(loc)}</loc>`);
+
+		if (lastmod) {
+			lines.push(`    <lastmod>${escapeSitemapXml(lastmod)}</lastmod>`);
+		}
+
+		lines.push("  </url>");
+	}
+
+	lines.push("</urlset>");
+	return lines.join("\n");
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,65 @@
+import { defineMiddleware } from "astro:middleware";
+
+import {
+	getPublishedPages,
+	getPublishedPosts,
+	getPublishedProjects,
+} from "./lib/content";
+import { renderSitemapXml, type SitemapInputEntry } from "./lib/sitemap";
+
+interface SitemapSourceEntry {
+	id: string;
+	updated_at?: string | null;
+	updatedAt?: string | Date | null;
+	published_at?: string | null;
+	publishedAt?: string | Date | null;
+	createdAt?: string | Date | null;
+	data: SitemapInputEntry["data"];
+}
+
+function toSitemapEntry(entry: SitemapSourceEntry): SitemapInputEntry {
+	return {
+		id: entry.id,
+		updated_at: entry.updated_at,
+		updatedAt: entry.updatedAt,
+		published_at: entry.published_at,
+		publishedAt: entry.publishedAt,
+		createdAt: entry.createdAt,
+		data: {
+			path: entry.data.path,
+			updated_at: entry.data.updated_at,
+			updatedAt: entry.data.updatedAt,
+			published_at: entry.data.published_at,
+			publishedAt: entry.data.publishedAt,
+			published_on: entry.data.published_on,
+		},
+	};
+}
+
+async function renderSitemapResponse(origin: string) {
+	const [pages, posts, projects] = await Promise.all([
+		getPublishedPages(),
+		getPublishedPosts(),
+		getPublishedProjects(),
+	]);
+	const body = renderSitemapXml(origin, [
+		...pages.map(toSitemapEntry),
+		...posts.map(toSitemapEntry),
+		...projects.map(toSitemapEntry),
+	]);
+
+	return new Response(body, {
+		headers: {
+			"Content-Type": "application/xml; charset=utf-8",
+			"Cache-Control": "public, max-age=3600",
+		},
+	});
+}
+
+export const onRequest = defineMiddleware((context, next) => {
+	if (context.url.pathname === "/sitemap.xml") {
+		return renderSitemapResponse(context.url.origin);
+	}
+
+	return next();
+});

--- a/tests/unit/sitemap.test.ts
+++ b/tests/unit/sitemap.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "vitest";
+
+import {
+	renderSitemapXml,
+	sitemapEntryLastmod,
+	sitemapPathToUrl,
+} from "../../src/lib/sitemap";
+
+describe("sitemap helpers", () => {
+	test("builds canonical URLs from migrated content paths", () => {
+		expect(sitemapPathToUrl("https://www.engagedphilosophy.com/", "")).toBe(
+			"https://www.engagedphilosophy.com/",
+		);
+		expect(
+			sitemapPathToUrl(
+				"https://www.engagedphilosophy.com",
+				"2022/05/31/jason-swartwood",
+			),
+		).toBe("https://www.engagedphilosophy.com/2022/05/31/jason-swartwood/");
+		expect(
+			sitemapPathToUrl("https://www.engagedphilosophy.com", " about/ "),
+		).toBe("https://www.engagedphilosophy.com/about/");
+	});
+
+	test("uses the best available timestamp for lastmod", () => {
+		expect(
+			sitemapEntryLastmod({
+				id: "post",
+				updatedAt: new Date("2026-06-07T00:00:00Z"),
+				data: {
+					path: "2022/05/31/jason-swartwood",
+					published_on: "2022-06-01T00:12:21Z",
+				},
+			}),
+		).toBe("2026-06-07T00:00:00.000Z");
+
+		expect(
+			sitemapEntryLastmod({
+				id: "page",
+				data: {
+					path: "about",
+					updatedAt: new Date("2026-06-07T00:00:00Z"),
+				},
+			}),
+		).toBe("2026-06-07T00:00:00.000Z");
+	});
+
+	test("renders unique XML sitemap URLs with escaped values", () => {
+		const xml = renderSitemapXml("https://www.engagedphilosophy.com", [
+			{
+				id: "home",
+				data: { path: "", updated_at: "2026-06-07T00:00:00Z" },
+			},
+			{
+				id: "project",
+				data: {
+					path: "project/a-b",
+					updated_at: "2026-06-07T00:00:00Z",
+				},
+			},
+			{
+				id: "duplicate",
+				data: {
+					path: "project/a-b",
+					updated_at: "2026-06-08T00:00:00Z",
+				},
+			},
+		]);
+
+		expect(xml).toContain("<urlset");
+		expect(xml.match(/<url>/g)).toHaveLength(2);
+		expect(xml).toContain(
+			[
+				"<loc>https://www.engagedphilosophy.com/project/a-b/</loc>",
+				"<lastmod>2026-06-08T00:00:00Z</lastmod>",
+			].join("\n    "),
+		);
+		expect(xml).toContain("<lastmod>2026-06-07T00:00:00Z</lastmod>");
+	});
+});


### PR DESCRIPTION
## Summary
- generate `/sitemap.xml` from published pages, posts, and projects using their WordPress-compatible public `data.path` values
- add unit coverage for sitemap URL/XML helpers
- add Worker-backed Playwright coverage for published page/post sitemap paths
- make the live sitemap smoke command fail when no public URLs are present

## Tests
- `mise exec -- pnpm exec vitest run tests/unit/sitemap.test.ts`
- `mise exec -- pnpm run typecheck`
- `mise exec -- pnpm run typecheck:tests`
- `mise exec -- pnpm run lint`
- `mise exec -- pnpm exec playwright test e2e/specs/public/sitemap.spec.ts`
- `mise exec -- pnpm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New `/sitemap.xml` endpoint generates and serves an XML sitemap listing all published pages, posts, and projects with their last-modified timestamps. Responses are cached for one hour to improve performance.

* **Tests**
  * Added comprehensive end-to-end and unit tests to validate sitemap generation, XML formatting, automatic deduplication, and proper HTTP response headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->