### PR TITLE
Improve CI diagnostics for Playwright failures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,8 @@ jobs:
           PLAYWRIGHT_VIDEO: "1"
         run: |
           set -o pipefail
+          cp -a test-results/e2e-static test-results/e2e-static-initial || true
+          cp -a playwright-report-static playwright-report-static-initial || true
           pnpm run test:static -- --last-failed 2>&1 | tee playwright-debug-static.log
 
       - name: Typecheck app
@@ -76,18 +78,24 @@ jobs:
           PLAYWRIGHT_VIDEO: "1"
         run: |
           set -o pipefail
+          cp -a test-results/e2e test-results/e2e-initial || true
+          cp -a playwright-report playwright-report-initial || true
           pnpm run test:e2e -- --last-failed 2>&1 | tee playwright-debug-e2e.log
 
       - name: Upload Playwright failure artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: playwright-failure-artifacts
           path: |
             test-results/e2e
+            test-results/e2e-initial
             test-results/e2e-static
+            test-results/e2e-static-initial
             playwright-report
+            playwright-report-initial
             playwright-report-static
+            playwright-report-static-initial
             playwright-debug-*.log
           if-no-files-found: ignore
           retention-days: 14

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,3 +51,16 @@ jobs:
 
       - name: Worker browser tests
         run: pnpm run test:e2e
+
+      - name: Upload Playwright failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-failure-artifacts
+          path: |
+            test-results/e2e
+            test-results/e2e-static
+            playwright-report
+            playwright-report-static
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,9 +32,20 @@ jobs:
         run: pnpm run test:unit
 
       - name: Static browser tests
+        id: static-browser-tests
         env:
           PLAYWRIGHT_VIDEO: "1"
         run: pnpm run test:static
+
+      - name: Static browser tests debug rerun
+        if: failure() && steps.static-browser-tests.outcome == 'failure'
+        continue-on-error: true
+        env:
+          DEBUG: pw:api
+          PLAYWRIGHT_VIDEO: "1"
+        run: |
+          set -o pipefail
+          pnpm run test:static -- --last-failed 2>&1 | tee playwright-debug-static.log
 
       - name: Typecheck app
         run: pnpm run typecheck
@@ -52,9 +63,20 @@ jobs:
         run: pnpm run test:worker-runtime
 
       - name: Worker browser tests
+        id: worker-browser-tests
         env:
           PLAYWRIGHT_VIDEO: "1"
         run: pnpm run test:e2e
+
+      - name: Worker browser tests debug rerun
+        if: failure() && steps.worker-browser-tests.outcome == 'failure'
+        continue-on-error: true
+        env:
+          DEBUG: pw:api
+          PLAYWRIGHT_VIDEO: "1"
+        run: |
+          set -o pipefail
+          pnpm run test:e2e -- --last-failed 2>&1 | tee playwright-debug-e2e.log
 
       - name: Upload Playwright failure artifacts
         if: failure()
@@ -66,5 +88,6 @@ jobs:
             test-results/e2e-static
             playwright-report
             playwright-report-static
+            playwright-debug-*.log
           if-no-files-found: ignore
           retention-days: 14

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,5 +25,29 @@ jobs:
       - name: Install browser
         run: pnpm exec playwright install --with-deps chromium
 
-      - name: Run CI checks
-        run: pnpm run ci
+      - name: Lint
+        run: pnpm run lint
+
+      - name: Unit tests
+        run: pnpm run test:unit
+
+      - name: Static browser tests
+        run: pnpm run test:static
+
+      - name: Typecheck app
+        run: pnpm run typecheck
+
+      - name: Typecheck tests
+        run: pnpm run typecheck:tests
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Worker bundle smoke test
+        run: pnpm run test:worker-bundle
+
+      - name: Worker runtime smoke test
+        run: pnpm run test:worker-runtime
+
+      - name: Worker browser tests
+        run: pnpm run test:e2e

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,8 @@ jobs:
         run: pnpm run test:unit
 
       - name: Static browser tests
+        env:
+          PLAYWRIGHT_VIDEO: "1"
         run: pnpm run test:static
 
       - name: Typecheck app
@@ -50,6 +52,8 @@ jobs:
         run: pnpm run test:worker-runtime
 
       - name: Worker browser tests
+        env:
+          PLAYWRIGHT_VIDEO: "1"
         run: pnpm run test:e2e
 
       - name: Upload Playwright failure artifacts

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -27,7 +27,7 @@ export default defineConfig({
 	retries: process.env.CI ? 1 : 0,
 	timeout: 30_000,
 	expect: {
-		timeout: 5000,
+		timeout: 7500,
 	},
 	outputDir: "test-results/e2e",
 	reporter: [

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
 	globalSetup: "./e2e/global-setup.ts",
 	fullyParallel: false,
 	workers: Number.isFinite(workers) && workers > 0 ? workers : 2,
+	retries: process.env.CI ? 1 : 0,
 	timeout: 30_000,
 	expect: {
 		timeout: 5000,

--- a/playwright.static.config.ts
+++ b/playwright.static.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
 	testDir: "./e2e-static/specs",
 	fullyParallel: false,
 	workers: 1,
+	retries: process.env.CI ? 1 : 0,
 	timeout: 30_000,
 	expect: {
 		timeout: 5000,


### PR DESCRIPTION
## Summary
- split the aggregate CI command into named workflow steps
- upload Playwright traces, screenshots, reports, videos, and debug logs when CI fails
- retry Playwright tests once in CI only
- retain Playwright videos only for failures in CI
- rerun failed browser tests with `DEBUG=pw:api` and save the debug output
- slightly relax the Worker-backed E2E assertion timeout

## Tests
- `mise exec -- pnpm run lint`
- `mise exec -- pnpm run typecheck:tests`
- `mise exec -- pnpm exec playwright test e2e/specs/admin/content-workflows.spec.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI workflow to run individual test steps separately with improved error reporting and artifact uploads for debugging purposes.

* **Tests**
  * Updated test configurations to automatically retry failed tests in CI environments and increased timeout thresholds for improved test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->