### PR TITLE
Enable Worker preview URLs in Wrangler config

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -2,6 +2,7 @@
 	"$schema": "node_modules/wrangler/config-schema.json",
 	"name": "engaged-philosophy",
 	"main": "./src/worker.ts",
+	"preview_urls": true,
 	"routes": [
 		{
 			"pattern": "engagedphilosophy.com",


### PR DESCRIPTION
## Summary
- set `preview_urls` in `wrangler.jsonc` so Wrangler deploys keep PR/branch preview URLs enabled

## Validation
- `mise exec -- pnpm exec prettier --check wrangler.jsonc`
- `mise exec -- pnpm exec wrangler deploy --dry-run`