### PR TITLE
Fix signed-in rendering for legacy Portable Text

### DIFF
--- a/e2e/specs/public/legacy-rendering.spec.ts
+++ b/e2e/specs/public/legacy-rendering.spec.ts
@@ -246,6 +246,24 @@ test.describe("public legacy rendering", () => {
 		await expectPageTextNotToContain(publicPage, "[gallery");
 		await expectPageTextNotToContain(publicPage, "[youtube");
 		await expectPageTextNotToContain(publicPage, "[playlist");
+
+		await publicPage.context().addCookies([
+			{
+				name: "astro-session",
+				value: "e2e-session-probe",
+				url: publicPage.url(),
+			},
+		]);
+		const signedInResponse = await publicPage.goto(publicPath, {
+			waitUntil: "domcontentloaded",
+			timeout: 10_000,
+		});
+		expect(signedInResponse?.status()).toBe(200);
+		await expect(publicPage.getByText(bodyText)).toBeVisible();
+		await expect(legacyImage).toHaveAttribute(
+			"src",
+			`${MEDIA_BASE}${LEGACY_IMAGE_PATH}`,
+		);
 	});
 
 	test("preserves centered legacy images, page lists, and mobile nav", async ({

--- a/src/components/RichContent.astro
+++ b/src/components/RichContent.astro
@@ -22,6 +22,15 @@ interface Props {
 
 const { value, class: className = "" } = Astro.props;
 const editMeta = getEditMeta(value);
+const legacyBlockTypes = new Set([
+	"break",
+	"gallery",
+	"legacyEmbed",
+	"legacyImage",
+	"legacyPageList",
+	"legacyVideo",
+	"numberedHeading",
+]);
 
 type NumberedPortableBlock = RichTextBlock & {
 	_type?: string;
@@ -61,8 +70,27 @@ function normalizeLegacyPortableText(blocks: RichTextValue) {
 	});
 }
 
+function hasLegacyPortableTextBlocks(blocks: RichTextValue) {
+	return blocks.some((block) => {
+		const portableBlock = block as NumberedPortableBlock;
+		return (
+			(typeof portableBlock?._type === "string" &&
+				legacyBlockTypes.has(portableBlock._type)) ||
+			(portableBlock?._type === "block" &&
+				typeof portableBlock.style === "string" &&
+				/^h[1-6]$/.test(portableBlock.style) &&
+				portableBlock.listItem === "number")
+		);
+	});
+}
+
+const hasLegacyBlocks = isPortableTextValue(value)
+	? hasLegacyPortableTextBlocks(value)
+	: false;
+// Imported legacy blocks render statically; the normalized copy also drops
+// EmDash edit metadata so the inline editor does not try to own them.
 const normalizedValue =
-	isPortableTextValue(value) && !editMeta
+	isPortableTextValue(value) && (!editMeta || hasLegacyBlocks)
 		? normalizeLegacyPortableText(value)
 		: value;
 ---


### PR DESCRIPTION
## Summary
- render imported legacy Portable Text blocks statically even when EmDash edit metadata is present
- keep normal Portable Text on EmDash's inline edit path
- add an e2e regression that reloads a legacy-content page with an `astro-session` cookie so the anonymous cache is bypassed

## Log evidence
- cookie-bearing `GET /about/` reached `ep.request.start`, emitted `ep.request.slow` at 10s, never emitted `ep.request.complete`, and was canceled by the client
- cookie-bearing `GET /` completed normally, so the issue is path/content-specific rather than Cloudflare Access itself
- `/about/` contains legacy imported Portable Text blocks such as `legacyImage`

## Validation
- `mise exec -- pnpm exec playwright test e2e/specs/public/legacy-rendering.spec.ts`
- `mise exec -- pnpm run lint`
- `mise exec -- pnpm run typecheck`
- `mise exec -- pnpm run build`