### PR TITLE
Add Dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
     schedule:
       interval: "daily"
       time: "09:00"
+    cooldown:
+      default-days: 4
     commit-message:
       prefix: "npm"
       prefix-development: "npm-dev"
@@ -20,6 +22,8 @@ updates:
     schedule:
       interval: "daily"
       time: "10:00"
+    cooldown:
+      default-days: 4
     commit-message:
       prefix: "ci"
       include: "scope"


### PR DESCRIPTION
## Summary
- add a 4-day Dependabot cooldown for npm version updates
- add the same cooldown for GitHub Actions version updates
- reduce Dependabot PRs opened before pnpm's minimum release age policy can pass

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml"); puts "dependabot.yml parsed"'
- mise exec -- pnpm run lint