### PR TITLE
Sync EmDash invites through a Cloudflare Access email list

### DIFF
--- a/docs/emdash-customizations.md
+++ b/docs/emdash-customizations.md
@@ -12,12 +12,34 @@ Cloudflare constraints.
   Access JWTs. EmDash users still need to exist in the EmDash auth tables.
 - `src/emdash-routes/cloudflare-access-invite.ts` replaces the default email
   invite flow with local user creation plus an admin URL, because sign-in is
-  protected by Cloudflare Access.
+  protected by Cloudflare Access. If configured, it also appends the invited
+  email to a Zero Trust EMAIL list referenced by the admin Access policy.
 - `src/lib/anonymous-cloudflare-cache.ts` caches anonymous HTML page responses in
   the Workers Cache API while bypassing signed-in, preview, admin, API, and
   static-asset requests.
 - `src/worker.ts` logs selected admin/signed-in request metadata and slow
   observed requests without serializing cookie values.
+
+### Cloudflare Access Invites
+
+To let EmDash user invites grant Zero Trust access, create a Zero Trust
+Reusable components EMAIL list for admin users and reference that list from the
+Access policy protecting `/_emdash*`, either directly or through a reusable rule
+group. Then configure the Worker with:
+
+- `CLOUDFLARE_ACCESS_INVITE_ACCOUNT_ID`: the Cloudflare account ID.
+- `CLOUDFLARE_ACCESS_INVITE_EMAIL_LIST_ID`: the Zero Trust EMAIL list ID.
+- `CLOUDFLARE_ACCESS_INVITE_EMAIL_LIST_API_TOKEN`: a Worker secret with
+  `Zero Trust Read` and `Zero Trust Write`.
+
+The route uses the Zero Trust list append API. It does not replace Access groups
+or policies at runtime, so concurrent manual removals from the list are not
+restored by a stale full-group write.
+
+If both the list ID and API token are absent, the invite route still creates the
+EmDash user and returns the admin URL plus a manual Access reminder, even if the
+account ID is present. If either the list ID or API token is set without the
+other required values, the route fails closed with `ACCESS_CONFIG_ERROR`.
 
 ## Plugins
 

--- a/e2e/specs/admin/invite-flow.spec.ts
+++ b/e2e/specs/admin/invite-flow.spec.ts
@@ -3,7 +3,7 @@ import { collectPageErrors } from "../../support/assertions";
 import { dismissWelcome } from "../../support/content";
 
 test.describe("admin user invites", () => {
-	test("creates a Cloudflare Access user and shows a manual invite link", async ({
+	test("creates an EmDash user and shows the admin sign-in link", async ({
 		page,
 	}, testInfo) => {
 		const pageErrors = collectPageErrors(page);

--- a/src/emdash-routes/cloudflare-access-invite.ts
+++ b/src/emdash-routes/cloudflare-access-invite.ts
@@ -4,9 +4,20 @@ import {
 	type AuthTables,
 } from "@emdash-cms/auth/adapters/kysely";
 import type { APIRoute } from "astro";
+import { env as cloudflareEnv } from "cloudflare:workers";
 import type { Kysely } from "kysely";
 
 import {
+	CloudflareAccessEmailListApiError,
+	CloudflareAccessEmailListConfigError,
+	syncCloudflareAccessEmailListEmail,
+	type CloudflareAccessEmailListConfig,
+	type CloudflareAccessEmailListSyncResult,
+} from "../lib/cloudflare-access-lists";
+import {
+	CLOUDFLARE_ACCESS_INVITE_EXISTING_USER_MESSAGE,
+	CLOUDFLARE_ACCESS_INVITE_EXISTING_USER_MANUAL_MESSAGE,
+	CLOUDFLARE_ACCESS_INVITE_MANUAL_MESSAGE,
 	CLOUDFLARE_ACCESS_INVITE_MESSAGE,
 	getCloudflareAccessInviteUrl,
 	normalizeCloudflareAccessInviteBody,
@@ -17,6 +28,15 @@ export const prerender = false;
 const JSON_HEADERS = {
 	"Cache-Control": "private, no-store",
 } as const;
+
+interface InviteRouteLocals {
+	emdash?: {
+		db?: unknown;
+	};
+	user?: {
+		role: number;
+	};
+}
 
 function apiSuccess(data: unknown, status = 200): Response {
 	return Response.json({ data }, { status, headers: JSON_HEADERS });
@@ -29,8 +49,45 @@ function apiError(code: string, message: string, status: number): Response {
 	);
 }
 
+function getRuntimeEnv(name: string): string | undefined {
+	const processValue =
+		typeof process !== "undefined" ? process.env?.[name] : undefined;
+	if (processValue) return processValue;
+
+	return (cloudflareEnv as Record<string, string | undefined>)[name];
+}
+
+function getCloudflareAccessEmailListConfig(): CloudflareAccessEmailListConfig {
+	return {
+		accountId: getRuntimeEnv("CLOUDFLARE_ACCESS_INVITE_ACCOUNT_ID"),
+		listId: getRuntimeEnv("CLOUDFLARE_ACCESS_INVITE_EMAIL_LIST_ID"),
+		apiToken: getRuntimeEnv("CLOUDFLARE_ACCESS_INVITE_EMAIL_LIST_API_TOKEN"),
+	};
+}
+
+function inviteSuccessData({
+	accessSync,
+	inviteUrl,
+	message,
+	userCreated,
+}: {
+	accessSync: CloudflareAccessEmailListSyncResult;
+	inviteUrl: string;
+	message: string;
+	userCreated: boolean;
+}) {
+	return {
+		success: true,
+		message,
+		inviteUrl,
+		zeroTrustUrl: accessSync.dashboardUrl,
+		cloudflareAccess: accessSync.status,
+		userCreated,
+	};
+}
+
 export const POST: APIRoute = async ({ request, locals }) => {
-	const { emdash, user } = locals;
+	const { emdash, user } = locals as InviteRouteLocals;
 
 	if (!emdash?.db) {
 		return apiError("NOT_CONFIGURED", "EmDash is not initialized", 500);
@@ -55,31 +112,86 @@ export const POST: APIRoute = async ({ request, locals }) => {
 	const adapter = createKyselyAdapter(
 		emdash.db as unknown as Kysely<AuthTables>,
 	);
+	const inviteUrl = getCloudflareAccessInviteUrl(request.url);
+	const accessEmailListConfig = getCloudflareAccessEmailListConfig();
 
 	try {
 		const existingUser = await adapter.getUserByEmail(invite.value.email);
 		if (existingUser) {
-			return apiError(
-				"USER_EXISTS",
-				"A user with this email already exists.",
-				409,
+			const accessSync = await syncCloudflareAccessEmailListEmail(
+				accessEmailListConfig,
+				invite.value.email,
+			);
+
+			return apiSuccess(
+				inviteSuccessData({
+					accessSync,
+					inviteUrl,
+					message:
+						accessSync.status === "not_configured"
+							? CLOUDFLARE_ACCESS_INVITE_EXISTING_USER_MANUAL_MESSAGE
+							: CLOUDFLARE_ACCESS_INVITE_EXISTING_USER_MESSAGE,
+					userCreated: false,
+				}),
 			);
 		}
 
-		await adapter.createUser({
+		const createdUser = await adapter.createUser({
 			email: invite.value.email,
 			role: invite.value.role,
 			emailVerified: true,
 		});
 
+		let accessSync: CloudflareAccessEmailListSyncResult;
+		try {
+			accessSync = await syncCloudflareAccessEmailListEmail(
+				accessEmailListConfig,
+				invite.value.email,
+			);
+		} catch (error) {
+			try {
+				await adapter.deleteUser(createdUser.id);
+			} catch (rollbackError) {
+				console.error(
+					"Failed to remove EmDash user after Cloudflare Access sync failure:",
+					rollbackError,
+				);
+				return apiError(
+					"ACCESS_ROLLBACK_ERROR",
+					"Cloudflare Access sync failed and the created EmDash user could not be removed. Manual cleanup is required.",
+					500,
+				);
+			}
+			throw error;
+		}
+
 		return apiSuccess({
-			success: true,
-			message: CLOUDFLARE_ACCESS_INVITE_MESSAGE,
-			inviteUrl: getCloudflareAccessInviteUrl(request.url),
+			...inviteSuccessData({
+				accessSync,
+				inviteUrl,
+				message:
+					accessSync.status === "not_configured"
+						? CLOUDFLARE_ACCESS_INVITE_MANUAL_MESSAGE
+						: CLOUDFLARE_ACCESS_INVITE_MESSAGE,
+				userCreated: true,
+			}),
 		});
 	} catch (error) {
 		if (error instanceof InviteError) {
 			return apiError(error.code.toUpperCase(), error.message, 400);
+		}
+
+		if (error instanceof CloudflareAccessEmailListConfigError) {
+			return apiError("ACCESS_CONFIG_ERROR", error.message, 500);
+		}
+
+		if (error instanceof CloudflareAccessEmailListApiError) {
+			console.error("Failed to update Cloudflare Access invite list:", error);
+			return apiError(
+				"ACCESS_UPDATE_ERROR",
+				"Failed to add user to Cloudflare Access.",
+				502,
+			);
 		}
 
 		console.error("Failed to create Cloudflare Access user invite:", error);

--- a/src/lib/cloudflare-access-invite.ts
+++ b/src/lib/cloudflare-access-invite.ts
@@ -4,7 +4,16 @@ const VALID_ROLE_LEVELS = new Set<number>(Object.values(Role));
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 export const CLOUDFLARE_ACCESS_INVITE_MESSAGE =
-	"User added. Share the admin URL with them and make sure Cloudflare Access allows their email.";
+	"User added to EmDash and Cloudflare Access. Share the admin URL with them.";
+
+export const CLOUDFLARE_ACCESS_INVITE_EXISTING_USER_MESSAGE =
+	"User already existed in EmDash and now has Cloudflare Access. Share the admin URL with them.";
+
+export const CLOUDFLARE_ACCESS_INVITE_MANUAL_MESSAGE =
+	"User added to EmDash. Add their email to the Cloudflare Access EMAIL list before sharing the admin URL.";
+
+export const CLOUDFLARE_ACCESS_INVITE_EXISTING_USER_MANUAL_MESSAGE =
+	"User already exists in EmDash. Add their email to the Cloudflare Access EMAIL list before sharing the admin URL.";
 
 export interface NormalizedCloudflareAccessInvite {
 	email: string;

--- a/src/lib/cloudflare-access-lists.ts
+++ b/src/lib/cloudflare-access-lists.ts
@@ -1,0 +1,369 @@
+const CLOUDFLARE_API_BASE_URL = "https://api.cloudflare.com/client/v4";
+const CLOUDFLARE_DASHBOARD_BASE_URL = "https://dash.cloudflare.com";
+const CLOUDFLARE_ACCESS_TIMEOUT_MS = 10_000;
+const LIST_ITEMS_PER_PAGE = 1000;
+
+interface CloudflareApiResponse<T> {
+	success?: boolean;
+	result?: T;
+	result_info?: {
+		page?: number;
+		count?: number;
+		per_page?: number;
+		total_count?: number;
+	};
+	errors?: Array<{ code?: number; message?: string }>;
+}
+
+interface CloudflareZeroTrustList {
+	id?: string;
+	name?: string;
+	type?: string;
+	items?: CloudflareZeroTrustListItem[];
+}
+
+interface CloudflareZeroTrustListItem {
+	value?: string;
+}
+
+export interface CloudflareAccessEmailListConfig {
+	accountId?: string;
+	listId?: string;
+	apiToken?: string;
+}
+
+export type CloudflareAccessEmailListSyncStatus =
+	| "added"
+	| "already_present"
+	| "not_configured";
+
+export interface CloudflareAccessEmailListSyncResult {
+	status: CloudflareAccessEmailListSyncStatus;
+	dashboardUrl: string;
+}
+
+interface ResolvedCloudflareAccessEmailListConfig {
+	accountId: string;
+	listId: string;
+	apiToken: string;
+}
+
+export class CloudflareAccessEmailListConfigError extends Error {
+	readonly missing: string[];
+
+	constructor(missing: string[]) {
+		super(
+			`Cloudflare Access email list sync is partially configured. Missing: ${missing.join(", ")}.`,
+		);
+		this.name = "CloudflareAccessEmailListConfigError";
+		this.missing = missing;
+	}
+}
+
+export class CloudflareAccessEmailListApiError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "CloudflareAccessEmailListApiError";
+	}
+}
+
+function cleanConfigValue(value: string | undefined): string | undefined {
+	const trimmed = value?.trim();
+	return trimmed ? trimmed : undefined;
+}
+
+function resolveConfig(
+	config: CloudflareAccessEmailListConfig,
+): ResolvedCloudflareAccessEmailListConfig | null {
+	const accountId = cleanConfigValue(config.accountId);
+	const listId = cleanConfigValue(config.listId);
+	const apiToken = cleanConfigValue(config.apiToken);
+	const missing: string[] = [];
+	if (!listId && !apiToken) return null;
+	if (!accountId) missing.push("CLOUDFLARE_ACCESS_INVITE_ACCOUNT_ID");
+	if (!listId) missing.push("CLOUDFLARE_ACCESS_INVITE_EMAIL_LIST_ID");
+	if (!apiToken) {
+		missing.push("CLOUDFLARE_ACCESS_INVITE_EMAIL_LIST_API_TOKEN");
+	}
+
+	if (missing.length > 0) {
+		throw new CloudflareAccessEmailListConfigError(missing);
+	}
+
+	return {
+		accountId: accountId as string,
+		listId: listId as string,
+		apiToken: apiToken as string,
+	};
+}
+
+export function getCloudflareAccessEmailListDashboardUrl(
+	accountId?: string,
+): string {
+	const cleanAccountId = cleanConfigValue(accountId);
+	if (!cleanAccountId) return CLOUDFLARE_DASHBOARD_BASE_URL;
+
+	return `${CLOUDFLARE_DASHBOARD_BASE_URL}/${encodeURIComponent(
+		cleanAccountId,
+	)}/zero-trust/lists`;
+}
+
+function getCloudflareAccessEmailListApiUrl(
+	config: ResolvedCloudflareAccessEmailListConfig,
+): string {
+	return `${CLOUDFLARE_API_BASE_URL}/accounts/${encodeURIComponent(
+		config.accountId,
+	)}/gateway/lists/${encodeURIComponent(config.listId)}`;
+}
+
+function getCloudflareAccessEmailListItemsApiUrl(
+	config: ResolvedCloudflareAccessEmailListConfig,
+	page: number,
+): string {
+	const url = new URL(`${getCloudflareAccessEmailListApiUrl(config)}/items`);
+	url.searchParams.set("page", String(page));
+	url.searchParams.set("per_page", String(LIST_ITEMS_PER_PAGE));
+	return url.toString();
+}
+
+async function readCloudflareResponse<T>(
+	response: Response,
+	action: string,
+): Promise<CloudflareApiResponse<T> & { result: T }> {
+	let body: CloudflareApiResponse<T>;
+	try {
+		body = (await response.json()) as CloudflareApiResponse<T>;
+	} catch {
+		throw new CloudflareAccessEmailListApiError(
+			`Cloudflare Zero Trust email list ${action} failed with HTTP ${response.status}.`,
+		);
+	}
+
+	if (!response.ok || body.success !== true || body.result === undefined) {
+		const details =
+			body.errors
+				?.map((error) => error.message)
+				.filter(Boolean)
+				.join("; ") || `HTTP ${response.status}`;
+
+		throw new CloudflareAccessEmailListApiError(
+			`Cloudflare Zero Trust email list ${action} failed: ${details}.`,
+		);
+	}
+
+	return body as CloudflareApiResponse<T> & { result: T };
+}
+
+async function fetchCloudflare(
+	url: string,
+	init: RequestInit,
+	action: string,
+	signal: AbortSignal,
+	fetchImpl: typeof fetch,
+): Promise<Response> {
+	try {
+		return await fetchImpl(url, { ...init, signal });
+	} catch (error) {
+		if (
+			signal.aborted ||
+			(error instanceof Error && error.name === "AbortError")
+		) {
+			throw new CloudflareAccessEmailListApiError(
+				`Cloudflare Zero Trust email list ${action} timed out.`,
+			);
+		}
+
+		const details =
+			error instanceof Error && error.message ? error.message : "unknown error";
+		throw new CloudflareAccessEmailListApiError(
+			`Cloudflare Zero Trust email list ${action} request failed: ${details}.`,
+		);
+	}
+}
+
+function normalizeEmail(value: string | undefined): string | undefined {
+	const trimmed = value?.trim().toLowerCase();
+	return trimmed ? trimmed : undefined;
+}
+
+function itemMatchesEmail(
+	item: CloudflareZeroTrustListItem,
+	email: string,
+): boolean {
+	return normalizeEmail(item.value) === email;
+}
+
+async function fetchEmailListDetails(
+	apiUrl: string,
+	headers: Record<string, string>,
+	signal: AbortSignal,
+	fetchImpl: typeof fetch,
+): Promise<CloudflareZeroTrustList> {
+	const { result } = await readCloudflareResponse<CloudflareZeroTrustList>(
+		await fetchCloudflare(apiUrl, { headers }, "lookup", signal, fetchImpl),
+		"lookup",
+	);
+
+	if (result.type !== "EMAIL") {
+		throw new CloudflareAccessEmailListApiError(
+			"Configured Cloudflare Zero Trust invite list must be an EMAIL list.",
+		);
+	}
+
+	return result;
+}
+
+async function emailListContains(
+	config: ResolvedCloudflareAccessEmailListConfig,
+	headers: Record<string, string>,
+	email: string,
+	signal: AbortSignal,
+	fetchImpl: typeof fetch,
+): Promise<boolean> {
+	let page = 1;
+
+	while (true) {
+		const { result, result_info: resultInfo } = await readCloudflareResponse<
+			CloudflareZeroTrustListItem[]
+		>(
+			await fetchCloudflare(
+				getCloudflareAccessEmailListItemsApiUrl(config, page),
+				{ headers },
+				"items lookup",
+				signal,
+				fetchImpl,
+			),
+			"items lookup",
+		);
+
+		if (result.some((item) => itemMatchesEmail(item, email))) return true;
+
+		const currentPage = resultInfo?.page ?? page;
+		const perPage = resultInfo?.per_page ?? LIST_ITEMS_PER_PAGE;
+		const returned = resultInfo?.count ?? result.length;
+		const total = resultInfo?.total_count ?? returned;
+		if (currentPage * perPage >= total || returned === 0) {
+			return false;
+		}
+		page = currentPage + 1;
+	}
+}
+
+async function appendEmailToList(
+	apiUrl: string,
+	headers: Record<string, string>,
+	email: string,
+	signal: AbortSignal,
+	fetchImpl: typeof fetch,
+): Promise<void> {
+	const { result } = await readCloudflareResponse<CloudflareZeroTrustList>(
+		await fetchCloudflare(
+			apiUrl,
+			{
+				method: "PATCH",
+				headers,
+				body: JSON.stringify({
+					append: [{ value: email, description: "EmDash admin invite" }],
+				}),
+			},
+			"append",
+			signal,
+			fetchImpl,
+		),
+		"append",
+	);
+
+	if (result.type !== undefined && result.type !== "EMAIL") {
+		throw new CloudflareAccessEmailListApiError(
+			"Configured Cloudflare Zero Trust invite list must be an EMAIL list.",
+		);
+	}
+}
+
+export async function syncCloudflareAccessEmailListEmail(
+	config: CloudflareAccessEmailListConfig,
+	email: string,
+	fetchImpl: typeof fetch = fetch,
+): Promise<CloudflareAccessEmailListSyncResult> {
+	const resolvedConfig = resolveConfig(config);
+	const dashboardUrl = getCloudflareAccessEmailListDashboardUrl(
+		config.accountId,
+	);
+	if (!resolvedConfig) {
+		return { status: "not_configured", dashboardUrl };
+	}
+
+	const normalizedEmail = normalizeEmail(email);
+	if (!normalizedEmail) {
+		throw new CloudflareAccessEmailListApiError(
+			"Cannot add an empty email to Cloudflare Access.",
+		);
+	}
+
+	const apiUrl = getCloudflareAccessEmailListApiUrl(resolvedConfig);
+	const headers = {
+		Authorization: `Bearer ${resolvedConfig.apiToken}`,
+		"Content-Type": "application/json",
+	};
+	const controller = new AbortController();
+	const timeout = setTimeout(
+		() => controller.abort(),
+		CLOUDFLARE_ACCESS_TIMEOUT_MS,
+	);
+
+	try {
+		await fetchEmailListDetails(apiUrl, headers, controller.signal, fetchImpl);
+		if (
+			await emailListContains(
+				resolvedConfig,
+				headers,
+				normalizedEmail,
+				controller.signal,
+				fetchImpl,
+			)
+		) {
+			return { status: "already_present", dashboardUrl };
+		}
+
+		try {
+			await appendEmailToList(
+				apiUrl,
+				headers,
+				normalizedEmail,
+				controller.signal,
+				fetchImpl,
+			);
+		} catch (error) {
+			if (
+				await emailListContains(
+					resolvedConfig,
+					headers,
+					normalizedEmail,
+					controller.signal,
+					fetchImpl,
+				)
+			) {
+				return { status: "already_present", dashboardUrl };
+			}
+			throw error;
+		}
+
+		if (
+			!(await emailListContains(
+				resolvedConfig,
+				headers,
+				normalizedEmail,
+				controller.signal,
+				fetchImpl,
+			))
+		) {
+			throw new CloudflareAccessEmailListApiError(
+				"Cloudflare Zero Trust email list append did not persist the invited email.",
+			);
+		}
+
+		return { status: "added", dashboardUrl };
+	} finally {
+		clearTimeout(timeout);
+	}
+}

--- a/tests/unit/admin-invite-access-sync.test.ts
+++ b/tests/unit/admin-invite-access-sync.test.ts
@@ -1,0 +1,161 @@
+import { Role } from "@emdash-cms/auth";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import type { CloudflareAccessEmailListSyncResult } from "../../src/lib/cloudflare-access-lists";
+
+const mocks = vi.hoisted(() => ({
+	adapter: {
+		getUserByEmail: vi.fn(),
+		createUser: vi.fn(),
+		deleteUser: vi.fn(),
+	},
+	syncCloudflareAccessEmailListEmail: vi.fn(),
+}));
+
+vi.mock("@emdash-cms/auth/adapters/kysely", () => ({
+	createKyselyAdapter: () => mocks.adapter,
+}));
+
+vi.mock("../../src/lib/cloudflare-access-lists", async (importOriginal) => {
+	const actual =
+		await importOriginal<
+			typeof import("../../src/lib/cloudflare-access-lists")
+		>();
+
+	return {
+		...actual,
+		syncCloudflareAccessEmailListEmail:
+			mocks.syncCloudflareAccessEmailListEmail,
+	};
+});
+
+const { CloudflareAccessEmailListApiError } =
+	await import("../../src/lib/cloudflare-access-lists");
+const { POST } =
+	await import("../../src/emdash-routes/cloudflare-access-invite");
+
+function createInviteRequest(body: unknown): Parameters<typeof POST>[0] {
+	return {
+		request: new Request("https://example.com/_emdash/api/auth/invite", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(body),
+		}),
+		locals: {
+			emdash: { db: {} },
+			user: { role: Role.ADMIN },
+		},
+	} as unknown as Parameters<typeof POST>[0];
+}
+
+function accessSyncResult(
+	status: CloudflareAccessEmailListSyncResult["status"],
+): CloudflareAccessEmailListSyncResult {
+	return {
+		status,
+		dashboardUrl: "https://dash.cloudflare.com/account/one/access/policies",
+	};
+}
+
+describe("Cloudflare Access invite route", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		for (const name of [
+			"CLOUDFLARE_ACCESS_INVITE_ACCOUNT_ID",
+			"CLOUDFLARE_ACCESS_INVITE_EMAIL_LIST_ID",
+			"CLOUDFLARE_ACCESS_INVITE_EMAIL_LIST_API_TOKEN",
+		]) {
+			delete process.env[name];
+		}
+	});
+
+	test("creates the EmDash user before granting Cloudflare Access", async () => {
+		const events: string[] = [];
+		mocks.adapter.getUserByEmail.mockResolvedValue(null);
+		mocks.adapter.createUser.mockImplementation(async () => {
+			events.push("create-user");
+			return { id: "user-id" };
+		});
+		mocks.syncCloudflareAccessEmailListEmail.mockImplementation(async () => {
+			events.push("sync-access");
+			return accessSyncResult("added");
+		});
+
+		const response = await POST(
+			createInviteRequest({ email: "person@example.com" }),
+		);
+
+		expect(response.status).toBe(200);
+		expect(events).toEqual(["create-user", "sync-access"]);
+		expect(mocks.adapter.createUser).toHaveBeenCalledWith({
+			email: "person@example.com",
+			role: Role.AUTHOR,
+			emailVerified: true,
+		});
+	});
+
+	test("returns manual Access instructions for an existing user when list sync is absent", async () => {
+		mocks.adapter.getUserByEmail.mockResolvedValue({
+			id: "user-id",
+			email: "person@example.com",
+		});
+		mocks.syncCloudflareAccessEmailListEmail.mockResolvedValue(
+			accessSyncResult("not_configured"),
+		);
+
+		const response = await POST(
+			createInviteRequest({ email: "person@example.com" }),
+		);
+		const body = (await response.json()) as {
+			data: { cloudflareAccess: string; message: string; userCreated: boolean };
+		};
+
+		expect(response.status).toBe(200);
+		expect(body.data.cloudflareAccess).toBe("not_configured");
+		expect(body.data.userCreated).toBe(false);
+		expect(body.data.message).toContain("already exists in EmDash");
+	});
+
+	test("removes a newly created EmDash user when Access sync fails", async () => {
+		const events: string[] = [];
+		mocks.adapter.getUserByEmail.mockResolvedValue(null);
+		mocks.adapter.createUser.mockImplementation(async () => {
+			events.push("create-user");
+			return { id: "user-id" };
+		});
+		mocks.syncCloudflareAccessEmailListEmail.mockImplementation(async () => {
+			events.push("sync-access");
+			throw new CloudflareAccessEmailListApiError("Access update failed.");
+		});
+		mocks.adapter.deleteUser.mockImplementation(async () => {
+			events.push("delete-user");
+		});
+
+		const response = await POST(
+			createInviteRequest({ email: "person@example.com" }),
+		);
+		const body = (await response.json()) as { error: { code: string } };
+
+		expect(response.status).toBe(502);
+		expect(body.error.code).toBe("ACCESS_UPDATE_ERROR");
+		expect(events).toEqual(["create-user", "sync-access", "delete-user"]);
+		expect(mocks.adapter.deleteUser).toHaveBeenCalledWith("user-id");
+	});
+
+	test("reports when rollback fails after Access sync fails", async () => {
+		mocks.adapter.getUserByEmail.mockResolvedValue(null);
+		mocks.adapter.createUser.mockResolvedValue({ id: "user-id" });
+		mocks.syncCloudflareAccessEmailListEmail.mockRejectedValue(
+			new CloudflareAccessEmailListApiError("Access update failed."),
+		);
+		mocks.adapter.deleteUser.mockRejectedValue(new Error("D1 unavailable"));
+
+		const response = await POST(
+			createInviteRequest({ email: "person@example.com" }),
+		);
+		const body = (await response.json()) as { error: { code: string } };
+
+		expect(response.status).toBe(500);
+		expect(body.error.code).toBe("ACCESS_ROLLBACK_ERROR");
+	});
+});

--- a/tests/unit/invite-access-list-sync.test.ts
+++ b/tests/unit/invite-access-list-sync.test.ts
@@ -1,0 +1,423 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import {
+	CloudflareAccessEmailListConfigError,
+	CloudflareAccessEmailListApiError,
+	getCloudflareAccessEmailListDashboardUrl,
+	syncCloudflareAccessEmailListEmail,
+} from "../../src/lib/cloudflare-access-lists";
+
+interface FetchCall {
+	url: string;
+	init?: RequestInit;
+}
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+function createJsonResponse(body: unknown, status = 200): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "Content-Type": "application/json" },
+	});
+}
+
+function createFetchImpl(calls: FetchCall[]): typeof fetch {
+	let appended = false;
+	return async (input, init) => {
+		calls.push({ url: String(input), init });
+		if (String(input).endsWith("/gateway/lists/list-id")) {
+			if (init?.method === "PATCH") {
+				appended = true;
+			}
+
+			return createJsonResponse({
+				success: true,
+				result: {
+					id: "list-id",
+					name: "EmDash admin invitees",
+					type: "EMAIL",
+				},
+			});
+		}
+
+		if (String(input).includes("/gateway/lists/list-id/items")) {
+			return createJsonResponse({
+				success: true,
+				result: appended
+					? [{ value: "admin@example.com" }, { value: "newuser@example.com" }]
+					: [{ value: "admin@example.com" }],
+				result_info: {
+					page: 1,
+					count: appended ? 2 : 1,
+					per_page: 1000,
+					total_count: appended ? 2 : 1,
+				},
+			});
+		}
+
+		return createJsonResponse({
+			success: true,
+			result: {
+				id: "list-id",
+				name: "EmDash admin invitees",
+				type: "EMAIL",
+				items: [
+					{ value: "admin@example.com" },
+					{ value: "newuser@example.com" },
+				],
+			},
+		});
+	};
+}
+
+describe("Cloudflare Access email list helpers", () => {
+	test("builds a Zero Trust lists dashboard URL", () => {
+		expect(getCloudflareAccessEmailListDashboardUrl("account-id")).toBe(
+			"https://dash.cloudflare.com/account-id/zero-trust/lists",
+		);
+		expect(getCloudflareAccessEmailListDashboardUrl()).toBe(
+			"https://dash.cloudflare.com",
+		);
+	});
+
+	test("skips Cloudflare calls when list sync is not configured", async () => {
+		const calls: FetchCall[] = [];
+		const fetchImpl: typeof fetch = async (input, init) => {
+			calls.push({ url: String(input), init });
+			return createJsonResponse({ success: true, result: {} });
+		};
+
+		await expect(
+			syncCloudflareAccessEmailListEmail({}, "user@example.com", fetchImpl),
+		).resolves.toEqual({
+			status: "not_configured",
+			dashboardUrl: "https://dash.cloudflare.com",
+		});
+		expect(calls).toHaveLength(0);
+	});
+
+	test("ignores a legacy account ID secret when list sync is otherwise absent", async () => {
+		const calls: FetchCall[] = [];
+		const fetchImpl: typeof fetch = async (input, init) => {
+			calls.push({ url: String(input), init });
+			return createJsonResponse({ success: true, result: {} });
+		};
+
+		await expect(
+			syncCloudflareAccessEmailListEmail(
+				{ accountId: "account-id" },
+				"user@example.com",
+				fetchImpl,
+			),
+		).resolves.toEqual({
+			status: "not_configured",
+			dashboardUrl: "https://dash.cloudflare.com/account-id/zero-trust/lists",
+		});
+		expect(calls).toHaveLength(0);
+	});
+
+	test("fails when list sync is partially configured", async () => {
+		await expect(
+			syncCloudflareAccessEmailListEmail(
+				{
+					accountId: "account-id",
+					listId: "list-id",
+				},
+				"user@example.com",
+			),
+		).rejects.toBeInstanceOf(CloudflareAccessEmailListConfigError);
+	});
+
+	test("appends a missing email to a Zero Trust email list", async () => {
+		const calls: FetchCall[] = [];
+		let itemLookupCount = 0;
+		const fetchImpl: typeof fetch = async (input, init) => {
+			calls.push({ url: String(input), init });
+			if (String(input).endsWith("/gateway/lists/list-id")) {
+				if (init?.method === "PATCH") {
+					return createJsonResponse({
+						success: true,
+						result: {
+							id: "list-id",
+							name: "EmDash admin invitees",
+							type: "EMAIL",
+						},
+					});
+				}
+
+				return createJsonResponse({
+					success: true,
+					result: {
+						id: "list-id",
+						name: "EmDash admin invitees",
+						type: "EMAIL",
+					},
+				});
+			}
+
+			itemLookupCount += 1;
+			return createJsonResponse({
+				success: true,
+				result:
+					itemLookupCount === 1
+						? [{ value: "admin@example.com" }]
+						: [
+								{ value: "admin@example.com" },
+								{ value: "newuser@example.com" },
+							],
+				result_info: {
+					page: 1,
+					count: itemLookupCount === 1 ? 1 : 2,
+					per_page: 1000,
+					total_count: itemLookupCount === 1 ? 1 : 2,
+				},
+			});
+		};
+
+		await expect(
+			syncCloudflareAccessEmailListEmail(
+				{
+					accountId: "account-id",
+					listId: "list-id",
+					apiToken: "secret-token",
+				},
+				"NewUser@Example.com",
+				fetchImpl,
+			),
+		).resolves.toEqual({
+			status: "added",
+			dashboardUrl: "https://dash.cloudflare.com/account-id/zero-trust/lists",
+		});
+
+		expect(calls.map((call) => call.init?.method ?? "GET")).toEqual([
+			"GET",
+			"GET",
+			"PATCH",
+			"GET",
+		]);
+		expect(calls[2]?.url).toBe(
+			"https://api.cloudflare.com/client/v4/accounts/account-id/gateway/lists/list-id",
+		);
+		expect(calls[2]?.init?.headers).toMatchObject({
+			Authorization: "Bearer secret-token",
+			"Content-Type": "application/json",
+		});
+		expect(JSON.parse(String(calls[2]?.init?.body))).toEqual({
+			append: [
+				{
+					value: "newuser@example.com",
+					description: "EmDash admin invite",
+				},
+			],
+		});
+	});
+
+	test("does not append when the email already exists", async () => {
+		const calls: FetchCall[] = [];
+		const fetchImpl: typeof fetch = async (input, init) => {
+			calls.push({ url: String(input), init });
+			if (String(input).endsWith("/gateway/lists/list-id")) {
+				return createJsonResponse({
+					success: true,
+					result: {
+						id: "list-id",
+						name: "EmDash admin invitees",
+						type: "EMAIL",
+					},
+				});
+			}
+
+			return createJsonResponse({
+				success: true,
+				result: [{ value: "user@example.com" }],
+				result_info: {
+					page: 1,
+					count: 1,
+					per_page: 1000,
+					total_count: 1,
+				},
+			});
+		};
+
+		await expect(
+			syncCloudflareAccessEmailListEmail(
+				{
+					accountId: "account-id",
+					listId: "list-id",
+					apiToken: "secret-token",
+				},
+				"USER@example.com",
+				fetchImpl,
+			),
+		).resolves.toEqual({
+			status: "already_present",
+			dashboardUrl: "https://dash.cloudflare.com/account-id/zero-trust/lists",
+		});
+		expect(calls.map((call) => call.init?.method ?? "GET")).toEqual([
+			"GET",
+			"GET",
+		]);
+	});
+
+	test("treats a duplicate append race as already present", async () => {
+		const calls: FetchCall[] = [];
+		let itemLookupCount = 0;
+		const fetchImpl: typeof fetch = async (input, init) => {
+			calls.push({ url: String(input), init });
+			if (String(input).endsWith("/gateway/lists/list-id")) {
+				if (init?.method === "PATCH") {
+					return createJsonResponse(
+						{
+							success: false,
+							errors: [{ message: "duplicate list item" }],
+						},
+						409,
+					);
+				}
+
+				return createJsonResponse({
+					success: true,
+					result: {
+						id: "list-id",
+						name: "EmDash admin invitees",
+						type: "EMAIL",
+					},
+				});
+			}
+
+			itemLookupCount += 1;
+			return createJsonResponse({
+				success: true,
+				result: itemLookupCount === 1 ? [] : [{ value: "newuser@example.com" }],
+				result_info: {
+					page: 1,
+					count: itemLookupCount === 1 ? 0 : 1,
+					per_page: 1000,
+					total_count: itemLookupCount === 1 ? 0 : 1,
+				},
+			});
+		};
+
+		await expect(
+			syncCloudflareAccessEmailListEmail(
+				{
+					accountId: "account-id",
+					listId: "list-id",
+					apiToken: "secret-token",
+				},
+				"newuser@example.com",
+				fetchImpl,
+			),
+		).resolves.toEqual({
+			status: "already_present",
+			dashboardUrl: "https://dash.cloudflare.com/account-id/zero-trust/lists",
+		});
+	});
+
+	test("rejects a configured invite list that is not an email list", async () => {
+		const fetchImpl: typeof fetch = async () =>
+			createJsonResponse({
+				success: true,
+				result: {
+					id: "list-id",
+					name: "Admin IPs",
+					type: "IP",
+				},
+			});
+
+		await expect(
+			syncCloudflareAccessEmailListEmail(
+				{
+					accountId: "account-id",
+					listId: "list-id",
+					apiToken: "secret-token",
+				},
+				"user@example.com",
+				fetchImpl,
+			),
+		).rejects.toThrow("EMAIL list");
+	});
+
+	test("does not use the Access group full replacement endpoint", async () => {
+		const calls: FetchCall[] = [];
+
+		await syncCloudflareAccessEmailListEmail(
+			{
+				accountId: "account-id",
+				listId: "list-id",
+				apiToken: "secret-token",
+			},
+			"newuser@example.com",
+			createFetchImpl(calls),
+		);
+
+		expect(calls.some((call) => call.url.includes("/access/groups/"))).toBe(
+			false,
+		);
+		expect(calls.some((call) => call.init?.method === "PUT")).toBe(false);
+	});
+
+	test("times out stalled Cloudflare requests", async () => {
+		vi.useFakeTimers();
+		const fetchImpl: typeof fetch = async (_input, init) =>
+			new Promise<Response>((_resolve, reject) => {
+				init?.signal?.addEventListener("abort", () => {
+					reject(new DOMException("The operation was aborted.", "AbortError"));
+				});
+			});
+
+		const syncError = syncCloudflareAccessEmailListEmail(
+			{
+				accountId: "account-id",
+				listId: "list-id",
+				apiToken: "secret-token",
+			},
+			"user@example.com",
+			fetchImpl,
+		).catch((error: unknown) => error);
+
+		await vi.advanceTimersByTimeAsync(10_000);
+		const error = await syncError;
+		expect(error).toBeInstanceOf(CloudflareAccessEmailListApiError);
+		expect(error).toMatchObject({
+			message: expect.stringContaining("timed out"),
+		});
+	});
+
+	test("does not include the API token in Cloudflare error messages", async () => {
+		const fetchImpl: typeof fetch = async () =>
+			createJsonResponse(
+				{
+					success: false,
+					errors: [{ message: "list not found" }],
+				},
+				404,
+			);
+
+		await expect(
+			syncCloudflareAccessEmailListEmail(
+				{
+					accountId: "account-id",
+					listId: "list-id",
+					apiToken: "secret-token",
+				},
+				"user@example.com",
+				fetchImpl,
+			),
+		).rejects.toThrow("list not found");
+
+		await expect(
+			syncCloudflareAccessEmailListEmail(
+				{
+					accountId: "account-id",
+					listId: "list-id",
+					apiToken: "secret-token",
+				},
+				"user@example.com",
+				fetchImpl,
+			),
+		).rejects.not.toThrow("secret-token");
+	});
+});


### PR DESCRIPTION
## Summary
- replace invite-time Cloudflare Access group full updates with Zero Trust EMAIL list append calls
- create the EmDash user before granting Cloudflare Access and roll it back if Access sync fails
- document the EMAIL list setup and add unit coverage for list append behavior, route ordering, and rollback

## Cloudflare setup already done
- created the `EmDash admin invitees` Zero Trust EMAIL list and seeded current admin emails
- added the EMAIL list to the admin Access policy
- created a narrow Zero Trust read/write runtime token and stored the new Worker secrets

## Tests
- `pnpm exec vitest run tests/unit/cloudflare-access-lists.test.ts tests/unit/cloudflare-access-invite-route.test.ts tests/unit/cloudflare-access-invite.test.ts`
- `pnpm run test:unit`
- `pnpm run typecheck:tests`
- `pnpm run typecheck`
- `pnpm run lint:eslint -- src/lib/cloudflare-access-lists.ts src/emdash-routes/cloudflare-access-invite.ts tests/unit/cloudflare-access-lists.test.ts tests/unit/cloudflare-access-invite-route.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added invite-based access support that can add users and update Cloudflare Access email lists when configured.
  * Improved invite success messages, including clearer handling for existing users and manual approval flows.

* **Bug Fixes**
  * Invite requests now fail safely when access settings are only partially configured.
  * Added rollback behavior so a newly created user is removed if access sync fails.

* **Documentation**
  * Updated setup guidance for Cloudflare Access invite configuration and required environment settings.

* **Tests**
  * Added coverage for invite success, failure rollback, and access list syncing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->