### PR TITLE
Harden admin e2e heading assertions

### DIFF
--- a/e2e/specs/admin/invite-flow.spec.ts
+++ b/e2e/specs/admin/invite-flow.spec.ts
@@ -1,5 +1,8 @@
 import { test, expect } from "../../fixtures/worker";
-import { collectPageErrors } from "../../support/assertions";
+import {
+	collectPageErrors,
+	expectExactHeading,
+} from "../../support/assertions";
 import { dismissWelcome } from "../../support/content";
 
 test.describe("admin user invites", () => {
@@ -11,7 +14,7 @@ test.describe("admin user invites", () => {
 
 		await page.goto("/_emdash/admin/users", { waitUntil: "domcontentloaded" });
 		await dismissWelcome(page);
-		await expect(page.getByRole("heading", { name: "Users" })).toBeVisible();
+		await expectExactHeading(page, "Users");
 
 		await page.getByRole("button", { name: "Invite User" }).click();
 		const dialog = page.getByRole("dialog", { name: "Invite User" });

--- a/e2e/specs/admin/media.spec.ts
+++ b/e2e/specs/admin/media.spec.ts
@@ -1,5 +1,8 @@
 import { test, expect } from "../../fixtures/worker";
-import { collectPageErrors } from "../../support/assertions";
+import {
+	collectPageErrors,
+	expectExactHeading,
+} from "../../support/assertions";
 import { dismissWelcome } from "../../support/content";
 
 function svgBuffer(label: string) {
@@ -19,9 +22,7 @@ test.describe("admin media library", () => {
 
 		await page.goto("/_emdash/admin/media", { waitUntil: "domcontentloaded" });
 		await dismissWelcome(page);
-		await expect(
-			page.getByRole("heading", { name: "Media Library" }),
-		).toBeVisible();
+		await expectExactHeading(page, "Media Library");
 		await expect(
 			page.getByRole("button", { name: "Upload to Library" }),
 		).toBeVisible();
@@ -53,9 +54,7 @@ test.describe("admin media library", () => {
 		expect(uploadBody.data?.item?.filename).toBe(filename);
 
 		await page.reload({ waitUntil: "domcontentloaded" });
-		await expect(
-			page.getByRole("heading", { name: "Media Library" }),
-		).toBeVisible();
+		await expectExactHeading(page, "Media Library");
 		await page.getByLabel("Search media").fill(filename);
 		await expect(page.getByText(filename)).toBeVisible({ timeout: 10_000 });
 

--- a/e2e/specs/admin/navigation.spec.ts
+++ b/e2e/specs/admin/navigation.spec.ts
@@ -1,5 +1,8 @@
 import { test, expect } from "../../fixtures/worker";
-import { collectPageErrors } from "../../support/assertions";
+import {
+	collectPageErrors,
+	expectExactHeading,
+} from "../../support/assertions";
 import { dismissWelcome } from "../../support/content";
 
 test.describe("admin navigation", () => {
@@ -9,9 +12,7 @@ test.describe("admin navigation", () => {
 		const pageErrors = collectPageErrors(page);
 		await page.goto("/_emdash/admin", { waitUntil: "domcontentloaded" });
 		await dismissWelcome(page);
-		await expect(
-			page.getByRole("heading", { name: "Dashboard" }),
-		).toBeVisible();
+		await expectExactHeading(page, "Dashboard");
 
 		const destinations = [
 			{
@@ -54,9 +55,7 @@ test.describe("admin navigation", () => {
 				.first()
 				.click();
 			await expect(page).toHaveURL(new RegExp(`${destination.path}$`));
-			await expect(
-				page.getByRole("heading", { name: destination.heading }),
-			).toBeVisible();
+			await expectExactHeading(page, destination.heading);
 			await expect(page.getByText("Authentication required")).toHaveCount(0);
 		}
 

--- a/e2e/specs/editing/edit-mode-save.spec.ts
+++ b/e2e/specs/editing/edit-mode-save.spec.ts
@@ -1,7 +1,10 @@
 import type { Page, Response } from "@playwright/test";
 
 import { test, expect } from "../../fixtures/worker";
-import { collectPageErrors } from "../../support/assertions";
+import {
+	collectPageErrors,
+	expectExactHeading,
+} from "../../support/assertions";
 import {
 	createAndPublishContentViaApi,
 	dismissWelcome,
@@ -66,9 +69,7 @@ test.describe("visual editing", () => {
 
 		await page.goto("/_emdash/admin", { waitUntil: "domcontentloaded" });
 		await dismissWelcome(page);
-		await expect(
-			page.getByRole("heading", { name: "Dashboard" }),
-		).toBeVisible();
+		await expectExactHeading(page, "Dashboard");
 
 		await page.goto(publicPath, { waitUntil: "domcontentloaded" });
 		await expect(page.locator("#emdash-toolbar")).toBeVisible();

--- a/e2e/support/assertions.ts
+++ b/e2e/support/assertions.ts
@@ -1,6 +1,21 @@
 import type { APIRequestContext, Page } from "@playwright/test";
 import { expect } from "@playwright/test";
 
+export async function expectExactHeading(
+	page: Page,
+	name: string,
+	options: { level?: number; timeout?: number } = {},
+) {
+	const { level, timeout = 15_000 } = options;
+	await expect(
+		page.getByRole("heading", {
+			name,
+			exact: true,
+			...(level === undefined ? {} : { level }),
+		}),
+	).toBeVisible({ timeout });
+}
+
 export async function expectOkJson(
 	request: APIRequestContext,
 	pathName: string,

--- a/e2e/support/content.ts
+++ b/e2e/support/content.ts
@@ -1,6 +1,8 @@
 import type { APIRequestContext, Page } from "@playwright/test";
 import { expect } from "@playwright/test";
 
+import { expectExactHeading } from "./assertions";
+
 export type CollectionSlug = "pages" | "posts" | "projects";
 
 export interface ContentItem {
@@ -261,9 +263,7 @@ export async function createAndPublishContentViaAdmin(
 	});
 	await dismissWelcome(page, 5000);
 
-	await expect(
-		page.getByRole("heading", { name: `New ${SINGULAR_LABEL[collection]}` }),
-	).toBeVisible();
+	await expectExactHeading(page, `New ${SINGULAR_LABEL[collection]}`);
 	await page.getByLabel("Title", { exact: true }).fill(options.title);
 	if (options.slug) {
 		await page.getByLabel("Slug", { exact: true }).fill(options.slug);
@@ -337,9 +337,7 @@ export async function expectPublicContent(
 		`Expected ${pathName} to load`,
 	).toBeGreaterThanOrEqual(200);
 	expect(response?.status(), `Expected ${pathName} to load`).toBeLessThan(300);
-	await expect(
-		page.getByRole("heading", { level: 1, name: title }),
-	).toBeVisible();
+	await expectExactHeading(page, title, { level: 1 });
 	await expect(page.getByText(bodyText)).toBeVisible();
 	await expect(page.getByText("Authentication required")).toHaveCount(0);
 }


### PR DESCRIPTION
## Summary
- Add a shared exact-heading assertion helper for Playwright e2e tests.
- Use exact heading matching for admin page-ready checks to avoid substring collisions such as `Media Library` matching `Your media library is empty`.
- Give admin heading checks a 15s timeout to match the Worker-backed admin navigation budget and reduce CI-only render timing flakes.

## Context
The main-branch run failed in `e2e/specs/admin/navigation.spec.ts`: `getByRole('heading', { name: 'Media Library' })` matched both the page heading and the empty-state heading. The same run also had one transient invite-flow heading miss that passed on retry; the debug rerun passed all 14 e2e tests.

## Tests
- `pnpm run lint:eslint`
- `pnpm run test:e2e:admin`
- `pnpm run test:e2e`
- `pnpm run ci`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end checks for admin and editing flows.
  * Standardized page heading validation across key screens, making navigation, media, invite, and editing tests more precise and reliable.
  * Strengthened content-related checks to confirm pages display the expected titles after publish and reload actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->