### PR TITLE
Simplify rich text extraction and repair search

### DIFF
--- a/.emdash/seed.json
+++ b/.emdash/seed.json
@@ -27,7 +27,8 @@
 					"slug": "title",
 					"label": "Title",
 					"type": "string",
-					"required": true
+					"required": true,
+					"searchable": true
 				},
 				{
 					"slug": "path",
@@ -40,6 +41,7 @@
 					"slug": "content",
 					"label": "Content",
 					"type": "portableText",
+					"searchable": true,
 					"widget": "portableText"
 				},
 				{
@@ -113,7 +115,8 @@
 					"slug": "title",
 					"label": "Title",
 					"type": "string",
-					"required": true
+					"required": true,
+					"searchable": true
 				},
 				{
 					"slug": "path",
@@ -126,12 +129,14 @@
 					"slug": "excerpt",
 					"label": "Excerpt",
 					"type": "portableText",
+					"searchable": true,
 					"widget": "portableText"
 				},
 				{
 					"slug": "content",
 					"label": "Content",
 					"type": "portableText",
+					"searchable": true,
 					"widget": "portableText"
 				},
 				{
@@ -166,7 +171,8 @@
 					"slug": "title",
 					"label": "Title",
 					"type": "string",
-					"required": true
+					"required": true,
+					"searchable": true
 				},
 				{
 					"slug": "path",
@@ -179,12 +185,14 @@
 					"slug": "excerpt",
 					"label": "Excerpt",
 					"type": "portableText",
+					"searchable": true,
 					"widget": "portableText"
 				},
 				{
 					"slug": "content",
 					"label": "Content",
 					"type": "portableText",
+					"searchable": true,
 					"widget": "portableText"
 				},
 				{

--- a/docs/emdash-customizations.md
+++ b/docs/emdash-customizations.md
@@ -80,8 +80,17 @@ consuming the smaller KV write budget or requiring a paid service.
 - Imported numbered headings use EmDash's native Portable Text list and heading
   rendering. A CSS counter preserves interview numbering across the answer
   blocks between headings without changing ordinary ordered lists.
-- Legacy renderers remain for Animoto embeds, playlist videos, and page lists
-  that do not have direct EmDash equivalents.
+- Archive and search excerpts use EmDash's Portable Text plain-text extractor
+  for standard blocks. The site adapter only preserves the imported image-alt
+  and gallery-caption fallback behavior that EmDash cannot infer from the
+  nested legacy gallery shape.
+- Legacy renderers remain for Animoto embeds, playlist videos, and dynamic page
+  lists. EmDash does not support Animoto or the page-list behavior. Its
+  self-hosted embed currently forces videos into 16:9 and omits intrinsic
+  dimensions and `playsinline`, while its media component serves local files
+  through the Worker. Keeping the small video adapter therefore preserves the
+  square and portrait videos and direct public-R2 delivery on the Cloudflare
+  Free plan.
 
 ## Imported Field Names
 

--- a/e2e/specs/public/search.spec.ts
+++ b/e2e/specs/public/search.spec.ts
@@ -1,0 +1,66 @@
+import {
+	createAndPublishContentViaApi,
+	uniqueTitle,
+} from "../../support/content";
+import { expect, test } from "../../fixtures/worker";
+
+test.describe("public search", () => {
+	test("finds published content through the EmDash index", async ({
+		authedRequest,
+		publicPage,
+	}, testInfo) => {
+		const searchTerm = `searchable-${testInfo.workerIndex}-${Date.now()}`;
+		const title = uniqueTitle("E2E Search", testInfo.testId);
+
+		const { publicPath } = await createAndPublishContentViaApi(
+			authedRequest,
+			"pages",
+			{
+				title,
+				content: `${title} content containing ${searchTerm}.`,
+				data: {
+					content: [
+						{
+							_type: "block",
+							_key: "content",
+							style: "normal",
+							markDefs: [],
+							children: [
+								{
+									_type: "span",
+									_key: "content-text",
+									text: `${title} content containing ${searchTerm}.`,
+									marks: [],
+								},
+							],
+						},
+					],
+				},
+			},
+		);
+
+		const searchResponse = await authedRequest.get(
+			`/_emdash/api/search?q=${encodeURIComponent(searchTerm)}&collections=pages`,
+		);
+		expect(searchResponse.ok()).toBe(true);
+		await expect(searchResponse.json()).resolves.toMatchObject({
+			data: {
+				items: [{ collection: "pages" }],
+			},
+		});
+
+		await publicPage.goto(`/?s=${encodeURIComponent(searchTerm)}`);
+
+		await expect(
+			publicPage.getByRole("heading", {
+				name: `Search Results for: ${searchTerm}`,
+			}),
+		).toBeVisible();
+		await expect(
+			publicPage.getByRole("heading", { name: title }),
+		).toBeVisible();
+		await expect(
+			publicPage.getByRole("link", { name: "Continue reading →" }),
+		).toHaveAttribute("href", publicPath);
+	});
+});

--- a/src/lib/rich-text-types.ts
+++ b/src/lib/rich-text-types.ts
@@ -54,11 +54,4 @@ export interface RichTextPageListNode extends PortableTextBlock {
 	_type: "legacyPageList";
 }
 
-export type RichTextBlock =
-	| PortableTextBlock
-	| RichTextGalleryNode
-	| RichTextVideoNode
-	| RichTextEmbedNode
-	| RichTextPageListNode;
-
-export type RichTextValue = RichTextBlock[];
+export type RichTextValue = PortableTextBlock[];

--- a/src/lib/rich-text.ts
+++ b/src/lib/rich-text.ts
@@ -1,4 +1,4 @@
-import type { PortableTextBlock } from "emdash";
+import { extractPlainText, type PortableTextBlock } from "emdash";
 
 type RichTextFieldValue = PortableTextBlock[] | null | undefined;
 
@@ -52,36 +52,30 @@ function stripWordPressShortcodes(value: string) {
 	return value.replace(/\[(?:\/)?[a-z][\w-]*(?:[^\]]*)\]/gi, " ");
 }
 
+function getImageAlt(block: PortableTextBlock) {
+	return typeof block.alt === "string" ? block.alt : "";
+}
+
+function getGalleryImageText(block: PortableTextBlock) {
+	if (!("images" in block) || !Array.isArray(block.images)) return "";
+
+	return block.images
+		.map((image: { alt?: unknown; caption?: unknown }) =>
+			typeof image.alt === "string"
+				? image.alt
+				: typeof image.caption === "string"
+					? image.caption
+					: "",
+		)
+		.join(" ");
+}
+
 function portableTextToPlainText(value: PortableTextBlock[]) {
 	return value
 		.map((block) => {
-			if (block._type === "block" && Array.isArray(block.children)) {
-				const children = block.children as Array<{ text?: unknown }>;
-				return children
-					.map((child: { text?: unknown }) =>
-						typeof child.text === "string" ? child.text : "",
-					)
-					.join("");
-			}
-			if (block._type === "image") {
-				return typeof block.alt === "string" ? block.alt : "";
-			}
-			if ("images" in block && Array.isArray(block.images)) {
-				const images = block.images as Array<{
-					alt?: unknown;
-					caption?: unknown;
-				}>;
-				return images
-					.map((image) =>
-						typeof image.alt === "string"
-							? image.alt
-							: typeof image.caption === "string"
-								? image.caption
-								: "",
-					)
-					.join(" ");
-			}
-			return "";
+			if (block._type === "image") return getImageAlt(block);
+			if (block._type === "gallery") return getGalleryImageText(block);
+			return extractPlainText([block]);
 		})
 		.join(" ");
 }

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -89,7 +89,8 @@ export async function searchSite(
 				ids,
 			);
 			return entries.map(
-				(entry) => [`${collection}:${entry.id}`, entry] as const,
+				(entry) =>
+					[`${collection}:${entry.data.id || entry.id}`, entry] as const,
 			);
 		}),
 	);
@@ -106,7 +107,7 @@ export async function searchSite(
 
 		return [
 			{
-				id: entry.id,
+				id: hit.id,
 				kind: resultKind(collection),
 				title,
 				path,

--- a/tests/unit/rich-text.test.ts
+++ b/tests/unit/rich-text.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, test } from "vitest";
+
+import { getExcerptText, stripHtml } from "../../src/lib/rich-text";
+
+describe("rich text", () => {
+	test("uses EmDash text extraction for standard Portable Text blocks", () => {
+		expect(
+			stripHtml([
+				{
+					_type: "block",
+					_key: "intro",
+					style: "normal",
+					markDefs: [],
+					children: [
+						{
+							_type: "span",
+							_key: "intro-text",
+							text: "A standard paragraph.",
+							marks: [],
+						},
+					],
+				},
+				{
+					_type: "code",
+					_key: "example",
+					language: "text",
+					code: "standard code block",
+				},
+			]),
+		).toBe("A standard paragraph. standard code block");
+	});
+
+	test("preserves imported image and gallery excerpt text", () => {
+		expect(
+			stripHtml([
+				{
+					_type: "image",
+					_key: "image",
+					alt: "Image alt text",
+					caption: "Image caption is not duplicated",
+				},
+				{
+					_type: "gallery",
+					_key: "gallery",
+					images: [
+						{
+							_type: "image",
+							_key: "gallery-image-with-alt",
+							alt: "Gallery alt text",
+							caption: "Unused gallery caption",
+						},
+						{
+							_type: "image",
+							_key: "gallery-image-with-caption",
+							caption: "Gallery caption fallback",
+						},
+					],
+				},
+			]),
+		).toBe("Image alt text Gallery alt text Gallery caption fallback");
+	});
+
+	test("prefers an explicit excerpt over a generated excerpt", () => {
+		expect(
+			getExcerptText(
+				[
+					{
+						_type: "block",
+						_key: "excerpt",
+						style: "normal",
+						markDefs: [],
+						children: [
+							{
+								_type: "span",
+								_key: "excerpt-text",
+								text: "One two three four",
+								marks: [],
+							},
+						],
+					},
+				],
+				[
+					{
+						_type: "block",
+						_key: "content",
+						style: "normal",
+						markDefs: [],
+						children: [
+							{
+								_type: "span",
+								_key: "content-text",
+								text: "Content fallback",
+								marks: [],
+							},
+						],
+					},
+				],
+				3,
+			),
+		).toBe("One two three four");
+	});
+
+	test("applies the word limit to generated excerpts", () => {
+		expect(
+			getExcerptText(
+				undefined,
+				[
+					{
+						_type: "block",
+						_key: "content",
+						style: "normal",
+						markDefs: [],
+						children: [
+							{
+								_type: "span",
+								_key: "content-text",
+								text: "One two three four",
+								marks: [],
+							},
+						],
+					},
+				],
+				3,
+			),
+		).toBe("One two three");
+	});
+});

--- a/tests/unit/search.test.ts
+++ b/tests/unit/search.test.ts
@@ -42,9 +42,10 @@ describe("site search", () => {
 				if (collection === "projects") {
 					return [
 						{
-							id: "project-1",
+							id: "project-one",
 							edit: {},
 							data: {
+								id: "project-1",
 								title: "Project One",
 								path: "project/project-one",
 							},
@@ -53,9 +54,9 @@ describe("site search", () => {
 				}
 				return [
 					{
-						id: "page-1",
+						id: "about",
 						edit: {},
-						data: { title: "About", path: "about" },
+						data: { id: "page-1", title: "About", path: "about" },
 					},
 				];
 			},

--- a/tests/unit/seed.test.ts
+++ b/tests/unit/seed.test.ts
@@ -4,7 +4,11 @@ import { describe, expect, test } from "vitest";
 import { validateSeed } from "emdash";
 
 interface CheckedInSeed {
-	collections?: Array<{ slug?: string }>;
+	collections?: Array<{
+		slug?: string;
+		supports?: string[];
+		fields?: Array<{ slug?: string; searchable?: boolean }>;
+	}>;
 	content?: unknown;
 	[key: string]: unknown;
 }
@@ -39,6 +43,27 @@ describe("checked-in EmDash seed", () => {
 			expect(collectionSlugs.has(slug), `Missing ${slug} collection`).toBe(
 				true,
 			);
+		}
+	});
+
+	test("indexes the public search fields", () => {
+		for (const collection of seed.collections ?? []) {
+			if (!["pages", "posts", "projects"].includes(collection.slug ?? "")) {
+				continue;
+			}
+
+			expect(collection.supports).toContain("search");
+			const searchableFields = new Set(
+				collection.fields
+					?.filter((field) => field.searchable)
+					.map((field) => field.slug),
+			);
+			const expectedFields =
+				collection.slug === "pages"
+					? ["title", "content"]
+					: ["title", "excerpt", "content"];
+
+			expect(searchableFields).toEqual(new Set(expectedFields));
 		}
 	});
 


### PR DESCRIPTION
## Summary

- delegate standard Portable Text plain-text extraction to EmDash
- retain only the imported image-alt and nested-gallery compatibility behavior
- use EmDash's `PortableTextBlock[]` directly instead of a redundant local union
- configure native EmDash FTS indexes for public title, excerpt, and content fields
- hydrate FTS hits by their database IDs instead of Astro's slug-based entry IDs
- document why Animoto, playlist videos, and dynamic page lists still need site adapters

## Search fix

Production search had two pre-existing problems:

1. the collections declared `search` support but no fields were marked searchable, so EmDash had no FTS indexes
2. valid FTS hits use database IDs, while hydrated Astro collection entries expose slugs as `entry.id`; the site now joins on `entry.data.id`

The Worker-backed test creates and publishes content, verifies the native EmDash search hit, and verifies the public search page displays it.

## Production parity

- compared generated excerpts for all 246 published production entries
- 0 excerpts changed
- no content records are changed by this PR

## Cloudflare Free considerations

- uses indexed EmDash FTS instead of adding a full-table fallback
- keeps playlist videos on direct public R2 URLs rather than the Worker media proxy
- preserves intrinsic square and portrait video layouts and `playsinline`
- adds no paid Cloudflare features

## Tests

- `mise exec -- pnpm run ci`
  - 88 unit tests
  - 6 static Playwright tests
  - 17 Worker-backed Playwright tests
  - typechecks, production build, and Worker smoke checks
