### PR TITLE
Use EmDash-hydrated taxonomy terms

### DIFF
--- a/e2e/specs/public/taxonomy-rendering.spec.ts
+++ b/e2e/specs/public/taxonomy-rendering.spec.ts
@@ -1,0 +1,103 @@
+import { test, expect } from "../../fixtures/worker";
+import {
+	createAndPublishContentViaApi,
+	createTaxonomyTermViaApi,
+	deleteContentViaApi,
+	deleteTaxonomyTermViaApi,
+	uniqueTitle,
+} from "../../support/content";
+
+test("renders taxonomy terms hydrated onto public entries", async ({
+	authedRequest,
+	publicPage,
+}, testInfo) => {
+	const postTitle = uniqueTitle("E2E Hydrated Post Terms", testInfo.testId);
+	const projectTitle = uniqueTitle(
+		"E2E Hydrated Project Terms",
+		testInfo.testId,
+	);
+	const terms = [
+		{ taxonomy: "category", slug: "e2e-category", label: "E2E Category" },
+		{ taxonomy: "schools", slug: "e2e-school", label: "E2E College" },
+		{
+			taxonomy: "professors",
+			slug: "e2e-professor",
+			label: "E2E Professor",
+		},
+		{ taxonomy: "courses", slug: "e2e-course", label: "E2E Course" },
+		{
+			taxonomy: "semesters",
+			slug: "e2e-semester",
+			label: "E2E Semester",
+		},
+		{ taxonomy: "topic", slug: "e2e-topic-one", label: "E2E Topic One" },
+		{ taxonomy: "topic", slug: "e2e-topic-two", label: "E2E Topic Two" },
+	];
+
+	for (const { taxonomy, slug, label } of terms) {
+		await createTaxonomyTermViaApi(authedRequest, taxonomy, { slug, label });
+	}
+
+	const post = await createAndPublishContentViaApi(authedRequest, "posts", {
+		title: postTitle,
+		publishedAt: "2026-07-25T12:00:00.000Z",
+		taxonomies: {
+			category: ["e2e-category"],
+		},
+	});
+	const project = await createAndPublishContentViaApi(
+		authedRequest,
+		"projects",
+		{
+			title: projectTitle,
+			taxonomies: {
+				schools: ["e2e-school"],
+				professors: ["e2e-professor"],
+				courses: ["e2e-course"],
+				semesters: ["e2e-semester"],
+				topic: ["e2e-topic-one", "e2e-topic-two"],
+			},
+		},
+	);
+
+	try {
+		await publicPage.goto(post.publicPath, {
+			waitUntil: "domcontentloaded",
+		});
+		const categoryFooter = publicPage.locator(".cat-links");
+		await expect(categoryFooter).toContainText("Posted in");
+		await expect(
+			categoryFooter.getByRole("link", { name: "E2E Category" }),
+		).toHaveAttribute("href", "/category/e2e-category/");
+
+		await publicPage.goto(project.publicPath, {
+			waitUntil: "domcontentloaded",
+		});
+		const termList = publicPage.locator(".entry-content .well");
+		await expect(termList).toContainText("College");
+		await expect(
+			termList.getByRole("link", { name: "E2E College" }),
+		).toHaveAttribute("href", "/schools/e2e-school/");
+		await expect(
+			termList.getByRole("link", { name: "E2E Professor" }),
+		).toHaveAttribute("href", "/professors/e2e-professor/");
+		await expect(
+			termList.getByRole("link", { name: "E2E Course" }),
+		).toHaveAttribute("href", "/courses/e2e-course/");
+		await expect(
+			termList.getByRole("link", { name: "E2E Semester" }),
+		).toHaveAttribute("href", "/semesters/e2e-semester/");
+		await expect(
+			termList.getByRole("link", { name: "E2E Topic One" }),
+		).toHaveAttribute("href", "/topic/e2e-topic-one/");
+		await expect(
+			termList.getByRole("link", { name: "E2E Topic Two" }),
+		).toHaveAttribute("href", "/topic/e2e-topic-two/");
+	} finally {
+		await deleteContentViaApi(authedRequest, "posts", post.published.id);
+		await deleteContentViaApi(authedRequest, "projects", project.published.id);
+		for (const { taxonomy, slug } of terms.toReversed()) {
+			await deleteTaxonomyTermViaApi(authedRequest, taxonomy, slug);
+		}
+	}
+});

--- a/e2e/support/content.ts
+++ b/e2e/support/content.ts
@@ -23,6 +23,13 @@ export interface MediaItem {
 	url?: string;
 }
 
+export interface TaxonomyTerm {
+	id: string;
+	name: string;
+	slug: string;
+	label: string;
+}
+
 const SINGULAR_LABEL: Record<CollectionSlug, string> = {
 	pages: "Page",
 	posts: "Post",
@@ -154,12 +161,14 @@ export async function createContentViaApi(
 		slug?: string;
 		data?: Record<string, unknown>;
 		publishedAt?: string;
+		taxonomies?: Record<string, string[]>;
 	},
 ) {
 	const response = await request.post(`/_emdash/api/content/${collection}`, {
 		data: {
 			slug: options.slug,
 			publishedAt: options.publishedAt,
+			taxonomies: options.taxonomies,
 			data: {
 				title: options.title,
 				content: portableTextParagraph(options.content ?? options.title),
@@ -194,6 +203,33 @@ export async function uploadMediaViaApi(
 	});
 	const body = await expectJsonResponse(response, "upload media");
 	return body?.data?.item as MediaItem;
+}
+
+export async function createTaxonomyTermViaApi(
+	request: APIRequestContext,
+	taxonomy: string,
+	options: { slug: string; label: string },
+): Promise<TaxonomyTerm> {
+	const response = await request.post(
+		`/_emdash/api/taxonomies/${taxonomy}/terms`,
+		{ data: options },
+	);
+	const body = await expectJsonResponse(
+		response,
+		`create ${taxonomy} taxonomy term`,
+	);
+	return body?.data?.term as TaxonomyTerm;
+}
+
+export async function deleteTaxonomyTermViaApi(
+	request: APIRequestContext,
+	taxonomy: string,
+	slug: string,
+): Promise<void> {
+	const response = await request.delete(
+		`/_emdash/api/taxonomies/${taxonomy}/terms/${slug}`,
+	);
+	await expectJsonResponse(response, `delete ${taxonomy} taxonomy term`);
 }
 
 export async function publishContentViaApi(

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -24,13 +24,10 @@ import type {
 	SiteCollection,
 } from "./types";
 
-type TaxonomyMap = Record<string, string[]>;
-type EmDashTermsMap = Record<string, Array<{ slug: string; label: string }>>;
 type RuntimeEntry<T> = ContentEntry<T> & {
 	data: T & {
 		id?: string;
 		status?: string;
-		terms?: EmDashTermsMap;
 	};
 };
 type NormalizedEntryData<T> = Omit<T, "featured_image"> & {
@@ -302,36 +299,4 @@ export function getTaxonomyTerm(taxonomy: string, slug: string) {
 
 export async function getTaxonomyTerms(taxonomy: string) {
 	return flattenTerms(await getEmDashTaxonomyTerms(taxonomy));
-}
-
-export function getEntryTerms(
-	entry: {
-		data?: Record<string, unknown> & {
-			terms?: EmDashTermsMap;
-		};
-		taxonomies?: TaxonomyMap;
-	},
-	taxonomy: string,
-) {
-	return entry.data?.terms?.[taxonomy] ?? [];
-}
-
-export function getEntryTermSlugs(
-	entry: {
-		data?: Record<string, unknown> & {
-			terms?: EmDashTermsMap;
-		};
-		taxonomies?: TaxonomyMap;
-	},
-	taxonomy: string,
-) {
-	return getEntryTerms(entry, taxonomy).map((term) => term.slug);
-}
-
-export async function getTermsBySlugs(taxonomy: string, slugs: string[]) {
-	const uniqueSlugs = [...new Set(slugs)];
-	const terms = await Promise.all(
-		uniqueSlugs.map((slug) => getTerm(taxonomy, slug)),
-	);
-	return terms.filter((term) => term !== null);
 }

--- a/src/pages/[year]/[month]/[day]/[slug].astro
+++ b/src/pages/[year]/[month]/[day]/[slug].astro
@@ -3,11 +3,7 @@ import RichContent from "../../../../components/RichContent.astro";
 import ThemeSidebar from "../../../../components/ThemeSidebar.astro";
 import Base from "../../../../layouts/Base.astro";
 import { taxonomyCacheTag } from "../../../../lib/cache-tags";
-import {
-	getEntryTermSlugs,
-	getPostByPath,
-	getTermsBySlugs,
-} from "../../../../lib/content";
+import { getPostByPath } from "../../../../lib/content";
 import { joinPath } from "../../../../lib/path-utils";
 import { getEntryContent } from "../../../../lib/rich-text";
 
@@ -19,10 +15,7 @@ if (!post) {
 	return Astro.redirect("/404");
 }
 
-const categories = await getTermsBySlugs(
-	"category",
-	getEntryTermSlugs(post, "category"),
-);
+const categories = post.data.terms?.category ?? [];
 ---
 
 <Base

--- a/src/pages/project/[slug].astro
+++ b/src/pages/project/[slug].astro
@@ -3,7 +3,7 @@ import ProjectTermsList from "../../components/content/ProjectTermsList.astro";
 import RichContent from "../../components/RichContent.astro";
 import Base from "../../layouts/Base.astro";
 import { taxonomyCacheTag } from "../../lib/cache-tags";
-import { getEntryTerms, getProjectBySlug } from "../../lib/content";
+import { getProjectBySlug } from "../../lib/content";
 import { getEntryContent } from "../../lib/rich-text";
 import { PROJECT_TAXONOMIES } from "../../lib/taxonomy-utils";
 
@@ -14,17 +14,32 @@ if (!project) {
 	return Astro.redirect("/404");
 }
 
-const schools = getEntryTerms(project, "schools");
-const professors = getEntryTerms(project, "professors");
-const courses = getEntryTerms(project, "courses");
-const semesters = getEntryTerms(project, "semesters");
-const topics = getEntryTerms(project, "topic");
 const termGroups = [
-	{ label: "College", pathPrefix: "schools", terms: schools },
-	{ label: "Professor", pathPrefix: "professors", terms: professors },
-	{ label: "Course", pathPrefix: "courses", terms: courses },
-	{ label: "Semester", pathPrefix: "semesters", terms: semesters },
-	{ label: "Topics", pathPrefix: "topic", terms: topics },
+	{
+		label: "College",
+		pathPrefix: "schools",
+		terms: project.data.terms?.schools ?? [],
+	},
+	{
+		label: "Professor",
+		pathPrefix: "professors",
+		terms: project.data.terms?.professors ?? [],
+	},
+	{
+		label: "Course",
+		pathPrefix: "courses",
+		terms: project.data.terms?.courses ?? [],
+	},
+	{
+		label: "Semester",
+		pathPrefix: "semesters",
+		terms: project.data.terms?.semesters ?? [],
+	},
+	{
+		label: "Topics",
+		pathPrefix: "topic",
+		terms: project.data.terms?.topic ?? [],
+	},
 ];
 ---
 

--- a/tests/unit/content-retrieval-and-taxonomy.test.ts
+++ b/tests/unit/content-retrieval-and-taxonomy.test.ts
@@ -17,10 +17,10 @@ vi.mock("emdash", () => ({
 
 import {
 	getPageByPath,
+	getPostByPath,
 	getPostsPageByCategory,
 	getPublishedPages,
 	getRecentPosts,
-	getTermsBySlugs,
 } from "../../src/lib/content";
 
 function entry(id: string, data: Record<string, unknown>) {
@@ -119,19 +119,33 @@ describe("content retrieval and taxonomy", () => {
 		});
 	});
 
-	test("resolves only assigned taxonomy terms", async () => {
-		getTerm
-			.mockResolvedValueOnce({ slug: "ethics", label: "Ethics" })
-			.mockResolvedValueOnce({ slug: "teaching", label: "Teaching" });
+	test("preserves taxonomy terms hydrated by EmDash", async () => {
+		getEmDashEntry.mockResolvedValue({
+			entry: entry("post-1", {
+				slug: "first-post",
+				path: "2026/01/02/first-post",
+				title: "First post",
+				terms: {
+					category: [
+						{ slug: "ethics", label: "Ethics" },
+						{ slug: "teaching", label: "Teaching" },
+					],
+				},
+			}),
+		});
 
-		await expect(
-			getTermsBySlugs("category", ["ethics", "ethics", "teaching"]),
-		).resolves.toEqual([
-			{ slug: "ethics", label: "Ethics" },
-			{ slug: "teaching", label: "Teaching" },
-		]);
-		expect(getTerm).toHaveBeenCalledTimes(2);
-		expect(getTerm).toHaveBeenNthCalledWith(1, "category", "ethics");
-		expect(getTerm).toHaveBeenNthCalledWith(2, "category", "teaching");
+		await expect(getPostByPath("2026/01/02/first-post")).resolves.toMatchObject(
+			{
+				data: {
+					terms: {
+						category: [
+							{ slug: "ethics", label: "Ethics" },
+							{ slug: "teaching", label: "Teaching" },
+						],
+					},
+				},
+			},
+		);
+		expect(getTerm).not.toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
## Summary

- render post categories from the taxonomy terms EmDash hydrates onto each entry
- render project taxonomy groups from the same hydrated term data
- remove the redundant term lookup helpers and their extra `getTerm()` calls
- replace helper-specific coverage with a test that verifies normalized entries preserve hydrated terms without another lookup

## Why

EmDash already hydrates `entry.data.terms` in the content query. Reading that data directly follows the current EmDash template pattern and avoids unnecessary taxonomy lookups and count work on public post pages, which is especially useful on the Cloudflare Workers Free plan.

## Testing

- `mise exec -- pnpm run ci`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Taxonomy terms are now preserved and displayed correctly on post and project pages.
  * Category and project term links continue to work when entries have missing or incomplete taxonomy data.
  * Improved handling prevents unnecessary taxonomy lookups while maintaining existing page content and navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->