### PR TITLE
refactor: use EmDash runtime APIs directly

### DIFF
--- a/e2e/specs/public/cache-invalidation.spec.ts
+++ b/e2e/specs/public/cache-invalidation.spec.ts
@@ -5,8 +5,10 @@ import {
 	portableTextParagraph,
 	publishContentViaApi,
 	updateContentViaApi,
+	uploadMediaViaApi,
 	uniqueTitle,
 } from "../../support/content";
+import { PUBLIC_MEDIA_URL } from "../../../src/lib/site-config";
 
 test.describe("public page cache", () => {
 	test("caches generated metadata with its data dependencies", async ({
@@ -22,6 +24,53 @@ test.describe("public page cache", () => {
 			maxRedirects: 0,
 		});
 		expect(faviconResponse.headers()["cache-tag"]).toContain("site-settings");
+	});
+
+	test("advertises the public media URL for the browser favicon", async ({
+		authedRequest,
+		publicPage,
+	}, testInfo) => {
+		const filename = `e2e-favicon-${testInfo.workerIndex}-${Date.now()}.svg`;
+		const media = await uploadMediaViaApi(authedRequest, {
+			filename,
+			mimeType: "image/svg+xml",
+			buffer: Buffer.from(
+				'<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"></svg>',
+			),
+			width: 1,
+			height: 1,
+		});
+		expect(media.storageKey).toBeTruthy();
+
+		try {
+			const settingsResponse = await authedRequest.post(
+				"/_emdash/api/settings",
+				{
+					data: {
+						favicon: { mediaId: media.id },
+					},
+				},
+			);
+			expect(settingsResponse.ok()).toBe(true);
+
+			const pageResponse = await publicPage.request.get("/");
+			const html = await pageResponse.text();
+			const publicHref = `${PUBLIC_MEDIA_URL}/${media.storageKey}`;
+			const internalHref = `/_emdash/api/media/file/${media.storageKey}`;
+
+			expect(html).toContain(`href="${internalHref}"`);
+			expect(html).toContain(
+				`href="${publicHref}" type="image/svg+xml" sizes="1x1"`,
+			);
+			expect(html.indexOf(`href="${publicHref}"`)).toBeGreaterThan(
+				html.indexOf(`href="${internalHref}"`),
+			);
+		} finally {
+			const deleteResponse = await authedRequest.delete(
+				`/_emdash/api/media/${media.id}`,
+			);
+			expect(deleteResponse.ok()).toBe(true);
+		}
 	});
 
 	test("keeps stateful and query-string HTML out of the shared cache", async ({

--- a/e2e/specs/public/taxonomy-rendering.spec.ts
+++ b/e2e/specs/public/taxonomy-rendering.spec.ts
@@ -70,6 +70,20 @@ test("renders taxonomy terms hydrated onto public entries", async ({
 			categoryFooter.getByRole("link", { name: "E2E Category" }),
 		).toHaveAttribute("href", "/category/e2e-category/");
 
+		await publicPage.goto("/category/e2e-category/", {
+			waitUntil: "domcontentloaded",
+		});
+		await expect(
+			publicPage.getByRole("heading", {
+				name: "Category Archives: E2E Category",
+			}),
+		).toBeVisible();
+		await expect(
+			publicPage
+				.locator("#content")
+				.getByRole("link", { name: postTitle, exact: true }),
+		).toHaveAttribute("href", post.publicPath);
+
 		await publicPage.goto(project.publicPath, {
 			waitUntil: "domcontentloaded",
 		});
@@ -93,6 +107,21 @@ test("renders taxonomy terms hydrated onto public entries", async ({
 		await expect(
 			termList.getByRole("link", { name: "E2E Topic Two" }),
 		).toHaveAttribute("href", "/topic/e2e-topic-two/");
+
+		await publicPage.goto("/topic/e2e-topic-one/", {
+			waitUntil: "domcontentloaded",
+		});
+		await expect(
+			publicPage.getByRole("heading", {
+				name: "Project Topic: E2E Topic One",
+			}),
+		).toBeVisible();
+		await expect(
+			publicPage.getByRole("heading", { name: projectTitle, exact: true }),
+		).toBeVisible();
+		await expect(
+			publicPage.getByRole("link", { name: /Continue reading/ }),
+		).toHaveAttribute("href", project.publicPath);
 	} finally {
 		await deleteContentViaApi(authedRequest, "posts", post.published.id);
 		await deleteContentViaApi(authedRequest, "projects", project.published.id);

--- a/src/components/layout/PrimaryNav.astro
+++ b/src/components/layout/PrimaryNav.astro
@@ -1,10 +1,5 @@
 ---
-interface MenuItem {
-	label?: string;
-	url?: string;
-	target?: string;
-	children?: MenuItem[];
-}
+import type { MenuItem } from "emdash";
 
 interface Props {
 	menuItems: MenuItem[];
@@ -13,7 +8,7 @@ interface Props {
 
 const { menuItems, currentPath } = Astro.props;
 
-function isCurrentUrl(url?: string) {
+function isCurrentUrl(url: string) {
 	return url === currentPath || url === `${currentPath}/`;
 }
 ---
@@ -52,11 +47,11 @@ function isCurrentUrl(url?: string) {
 				<ul id="menu-main-menu" class="navbar-nav ms-auto">
 					{
 						menuItems.map((item) => {
-							const hasChildren = (item.children?.length ?? 0) > 0;
+							const hasChildren = item.children.length > 0;
 							const isActive = isCurrentUrl(item.url);
 							const isBranchActive =
 								hasChildren &&
-								item.children?.some((child) => isCurrentUrl(child.url));
+								item.children.some((child) => isCurrentUrl(child.url));
 
 							return (
 								<li
@@ -83,7 +78,7 @@ function isCurrentUrl(url?: string) {
 									</a>
 									{hasChildren && (
 										<ul class="dropdown-menu">
-											{(item.children ?? []).map((child) => (
+											{item.children.map((child) => (
 												<li class="menu-item nav-item">
 													<a
 														class="dropdown-item"

--- a/src/components/layout/SiteHead.astro
+++ b/src/components/layout/SiteHead.astro
@@ -4,9 +4,12 @@ import type { PublicPageContext } from "emdash";
 
 interface Props {
 	page: PublicPageContext;
+	faviconHref?: string;
+	faviconType?: string;
+	faviconSizes?: string;
 }
 
-const { page } = Astro.props;
+const { page, faviconHref, faviconType, faviconSizes } = Astro.props;
 ---
 
 <head>
@@ -15,6 +18,16 @@ const { page } = Astro.props;
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 	<title>{page.title}</title>
 	<EmDashHead page={page} />
+	{
+		faviconHref && (
+			<link
+				rel="icon"
+				href={faviconHref}
+				type={faviconType}
+				sizes={faviconSizes}
+			/>
+		)
+	}
 	<link rel="manifest" href="/site.webmanifest" />
 	<meta name="theme-color" content="#fd7e14" />
 	<meta name="msapplication-TileColor" content="#fd7e14" />

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -3,6 +3,7 @@ import PrimaryNav from "../components/layout/PrimaryNav.astro";
 import SiteFooter from "../components/layout/SiteFooter.astro";
 import SiteHead from "../components/layout/SiteHead.astro";
 import SiteHeader from "../components/layout/SiteHeader.astro";
+import { getConfiguredFaviconHref } from "../lib/favicon";
 import { getMediaUrlPrefix, rewriteInternalMediaFileUrl } from "../lib/media";
 import {
 	createSitePageContext,
@@ -50,6 +51,12 @@ const siteDescription = settings?.tagline || SITE_TAGLINE_FALLBACK;
 const menuItems = (await getMenu("primary"))?.items ?? [];
 const currentPath = Astro.url.pathname;
 const mediaUrlPrefix = getMediaUrlPrefix();
+const favicon = settings?.favicon;
+const faviconHref = getConfiguredFaviconHref(settings, mediaUrlPrefix);
+const faviconSizes =
+	favicon?.width && favicon?.height
+		? `${favicon.width}x${favicon.height}`
+		: undefined;
 const logo = settings?.logo;
 const logoSrc = logo?.url
 	? rewriteInternalMediaFileUrl(logo.url, mediaUrlPrefix)
@@ -68,7 +75,12 @@ const page = createSitePageContext({
 
 <!doctype html>
 <html class="no-js" lang="en-US">
-	<SiteHead page={page} />
+	<SiteHead
+		page={page}
+		faviconHref={faviconHref}
+		faviconType={favicon?.contentType}
+		faviconSizes={faviconSizes}
+	/>
 	<body class={bodyClass}>
 		<EmDashBodyStart page={page} />
 		<div class="container">

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -3,7 +3,6 @@ import PrimaryNav from "../components/layout/PrimaryNav.astro";
 import SiteFooter from "../components/layout/SiteFooter.astro";
 import SiteHead from "../components/layout/SiteHead.astro";
 import SiteHeader from "../components/layout/SiteHeader.astro";
-import { getPrimaryMenu, getRuntimeSiteSettings } from "../lib/content";
 import { getMediaUrlPrefix, rewriteInternalMediaFileUrl } from "../lib/media";
 import {
 	createSitePageContext,
@@ -16,6 +15,7 @@ import {
 	SITE_TAGLINE_FALLBACK,
 	SITE_TITLE_FALLBACK,
 } from "../lib/site-config";
+import { getMenu, getSiteSettings } from "emdash";
 import { EmDashBodyEnd, EmDashBodyStart } from "emdash/ui";
 import "../scss/style.scss";
 
@@ -44,10 +44,10 @@ Astro.cache.set({
 	swr: PUBLIC_EDGE_CACHE_SWR_SECONDS,
 	...(routeCacheTags.length > 0 ? { tags: routeCacheTags } : {}),
 });
-const settings = await getRuntimeSiteSettings();
+const settings = await getSiteSettings();
 const siteTitle = settings?.title || SITE_TITLE_FALLBACK;
 const siteDescription = settings?.tagline || SITE_TAGLINE_FALLBACK;
-const menuItems = await getPrimaryMenu();
+const menuItems = (await getMenu("primary"))?.items ?? [];
 const currentPath = Astro.url.pathname;
 const mediaUrlPrefix = getMediaUrlPrefix();
 const logo = settings?.logo;

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -1,10 +1,7 @@
 import {
 	getEmDashCollection,
 	getEmDashEntry,
-	getMenu,
-	getSiteSettings as getEmDashSiteSettings,
 	getTaxonomyTerms as getEmDashTaxonomyTerms,
-	getTerm,
 	type ContentEntry as EmDashContentEntry,
 } from "emdash";
 
@@ -218,14 +215,6 @@ export function getProjectsPageByTaxonomy(
 	});
 }
 
-export async function getRuntimeSiteSettings() {
-	return getEmDashSiteSettings();
-}
-
-export async function getPrimaryMenu() {
-	return (await getMenu("primary"))?.items ?? [];
-}
-
 export async function getPublishedPages() {
 	return getPublishedCollection("pages");
 }
@@ -291,10 +280,6 @@ export async function getProjectBySlug(slug: string) {
 	if (!entry) return null;
 	const project = normalizeEntry(entry, "projects");
 	return isPublicEntry(project) ? project : null;
-}
-
-export function getTaxonomyTerm(taxonomy: string, slug: string) {
-	return getTerm(taxonomy, slug);
 }
 
 export async function getTaxonomyTerms(taxonomy: string) {

--- a/src/pages/[taxonomy]/[slug].astro
+++ b/src/pages/[taxonomy]/[slug].astro
@@ -1,11 +1,9 @@
 ---
+import { getTerm } from "emdash";
+
 import Base from "../../layouts/Base.astro";
 import TaxonomyArchive from "../../components/TaxonomyArchive.astro";
-import {
-	getPageByPath,
-	getProjectsPageByTaxonomy,
-	getTaxonomyTerm,
-} from "../../lib/content";
+import { getPageByPath, getProjectsPageByTaxonomy } from "../../lib/content";
 import { getEntryContent } from "../../lib/rich-text";
 import { taxonomyCacheTag } from "../../lib/cache-tags";
 import { isProjectTaxonomy } from "../../lib/taxonomy-utils";
@@ -22,7 +20,7 @@ if (!isProjectArchive) {
 	}
 }
 
-const term = isProjectArchive ? await getTaxonomyTerm(taxonomy, slug) : null;
+const term = isProjectArchive ? await getTerm(taxonomy, slug) : null;
 
 if (isProjectArchive && !term) {
 	return Astro.redirect("/404");

--- a/src/pages/[taxonomy]/[slug]/page/[page].astro
+++ b/src/pages/[taxonomy]/[slug]/page/[page].astro
@@ -1,10 +1,9 @@
 ---
+import { getTerm } from "emdash";
+
 import Base from "../../../../layouts/Base.astro";
 import TaxonomyArchive from "../../../../components/TaxonomyArchive.astro";
-import {
-	getProjectsPageByTaxonomy,
-	getTaxonomyTerm,
-} from "../../../../lib/content";
+import { getProjectsPageByTaxonomy } from "../../../../lib/content";
 import { taxonomyCacheTag } from "../../../../lib/cache-tags";
 import { isProjectTaxonomy } from "../../../../lib/taxonomy-utils";
 
@@ -14,7 +13,7 @@ if (!isProjectTaxonomy(taxonomy)) {
 	return Astro.redirect("/404");
 }
 
-const term = await getTaxonomyTerm(taxonomy, slug);
+const term = await getTerm(taxonomy, slug);
 if (!term) {
 	return Astro.redirect("/404");
 }

--- a/src/pages/category/[slug].astro
+++ b/src/pages/category/[slug].astro
@@ -1,11 +1,13 @@
 ---
+import { getTerm } from "emdash";
+
 import CategoryArchive from "../../components/CategoryArchive.astro";
 import Base from "../../layouts/Base.astro";
 import { taxonomyCacheTag } from "../../lib/cache-tags";
-import { getPostsPageByCategory, getTaxonomyTerm } from "../../lib/content";
+import { getPostsPageByCategory } from "../../lib/content";
 
 const { slug = "" } = Astro.params;
-const term = await getTaxonomyTerm("category", slug);
+const term = await getTerm("category", slug);
 
 if (!term) {
 	return Astro.redirect("/404");

--- a/src/pages/category/[slug]/page/[page].astro
+++ b/src/pages/category/[slug]/page/[page].astro
@@ -1,14 +1,13 @@
 ---
+import { getTerm } from "emdash";
+
 import CategoryArchive from "../../../../components/CategoryArchive.astro";
 import Base from "../../../../layouts/Base.astro";
 import { taxonomyCacheTag } from "../../../../lib/cache-tags";
-import {
-	getPostsPageByCategory,
-	getTaxonomyTerm,
-} from "../../../../lib/content";
+import { getPostsPageByCategory } from "../../../../lib/content";
 
 const { slug = "", page = "1" } = Astro.params;
-const term = await getTaxonomyTerm("category", slug);
+const term = await getTerm("category", slug);
 
 if (!term) {
 	return Astro.redirect("/404");

--- a/src/pages/favicon.ico.ts
+++ b/src/pages/favicon.ico.ts
@@ -1,7 +1,7 @@
 import type { APIRoute } from "astro";
+import { getSiteSettings } from "emdash";
 
 import { SITE_SETTINGS_CACHE_TAG } from "../lib/cache-tags";
-import { getRuntimeSiteSettings } from "../lib/content";
 import { createFaviconResponse } from "../lib/favicon";
 import {
 	PUBLIC_EDGE_CACHE_MAX_AGE_SECONDS,
@@ -14,7 +14,7 @@ export const GET: APIRoute = async ({ cache, request }) => {
 		swr: PUBLIC_EDGE_CACHE_SWR_SECONDS,
 		tags: [SITE_SETTINGS_CACHE_TAG],
 	});
-	return createFaviconResponse(await getRuntimeSiteSettings(), {
+	return createFaviconResponse(await getSiteSettings(), {
 		requestUrl: request.url,
 	});
 };

--- a/src/pages/favicon.svg.ts
+++ b/src/pages/favicon.svg.ts
@@ -1,8 +1,8 @@
 import type { APIRoute } from "astro";
+import { getSiteSettings } from "emdash";
 
 import { SITE_SETTINGS_CACHE_TAG } from "../lib/cache-tags";
 import { createFaviconResponse } from "../lib/favicon";
-import { getRuntimeSiteSettings } from "../lib/content";
 import {
 	PUBLIC_EDGE_CACHE_MAX_AGE_SECONDS,
 	PUBLIC_EDGE_CACHE_SWR_SECONDS,
@@ -14,7 +14,7 @@ export const GET: APIRoute = async ({ cache, request }) => {
 		swr: PUBLIC_EDGE_CACHE_SWR_SECONDS,
 		tags: [SITE_SETTINGS_CACHE_TAG],
 	});
-	return createFaviconResponse(await getRuntimeSiteSettings(), {
+	return createFaviconResponse(await getSiteSettings(), {
 		requestUrl: request.url,
 	});
 };

--- a/src/pages/site.webmanifest.ts
+++ b/src/pages/site.webmanifest.ts
@@ -1,7 +1,7 @@
 import type { APIRoute } from "astro";
+import { getSiteSettings } from "emdash";
 
 import { SITE_SETTINGS_CACHE_TAG } from "../lib/cache-tags";
-import { getRuntimeSiteSettings } from "../lib/content";
 import { rewriteInternalMediaFileUrl } from "../lib/media";
 import {
 	PUBLIC_EDGE_CACHE_MAX_AGE_SECONDS,
@@ -16,7 +16,7 @@ export const GET: APIRoute = async ({ cache }) => {
 		swr: PUBLIC_EDGE_CACHE_SWR_SECONDS,
 		tags: [SITE_SETTINGS_CACHE_TAG],
 	});
-	const settings = await getRuntimeSiteSettings();
+	const settings = await getSiteSettings();
 	const siteTitle = settings?.title || SITE_TITLE_FALLBACK;
 	const favicon = settings?.favicon;
 	const icons = favicon?.url

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -1,11 +1,10 @@
 import type { APIRoute } from "astro";
-import { getSeoMeta, type ContentSeo } from "emdash";
+import { getSeoMeta, getSiteSettings, type ContentSeo } from "emdash";
 
 import {
 	getPublishedPages,
 	getPublishedPosts,
 	getPublishedProjects,
-	getRuntimeSiteSettings,
 } from "../lib/content";
 import { SITE_SETTINGS_CACHE_TAG } from "../lib/cache-tags";
 import {
@@ -61,7 +60,7 @@ export const GET: APIRoute = async ({ cache, url }) => {
 		tags: [SITE_SETTINGS_CACHE_TAG, "pages", "posts", "projects"],
 	});
 	const [settings, pages, posts, projects] = await Promise.all([
-		getRuntimeSiteSettings(),
+		getSiteSettings(),
 		getPublishedPages(),
 		getPublishedPosts(),
 		getPublishedProjects(),

--- a/tests/unit/content-retrieval-and-taxonomy.test.ts
+++ b/tests/unit/content-retrieval-and-taxonomy.test.ts
@@ -1,18 +1,14 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
-const { getEmDashCollection, getEmDashEntry, getTerm } = vi.hoisted(() => ({
+const { getEmDashCollection, getEmDashEntry } = vi.hoisted(() => ({
 	getEmDashCollection: vi.fn(),
 	getEmDashEntry: vi.fn(),
-	getTerm: vi.fn(),
 }));
 
 vi.mock("emdash", () => ({
 	getEmDashCollection,
 	getEmDashEntry,
-	getMenu: vi.fn(),
-	getSiteSettings: vi.fn(),
 	getTaxonomyTerms: vi.fn(),
-	getTerm,
 }));
 
 import {
@@ -146,6 +142,5 @@ describe("content retrieval and taxonomy", () => {
 				},
 			},
 		);
-		expect(getTerm).not.toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
## Summary

- call EmDash site settings, primary menu, and taxonomy term APIs directly from their consumers
- use EmDash’s exported MenuItem type in the primary navigation
- remove the local pass-through wrappers and obsolete test mocks
- extend Worker-backed coverage to verify category and project taxonomy archives resolve terms and canonical entry links
- advertise the configured favicon through its public R2 URL after EmDash metadata, because Cloudflare Access protects EmDash’s internal media route

This keeps the site-specific content normalization, path, visibility, pagination, media, and cache behavior unchanged. The favicon remains direct public-R2 delivery, so it adds no Worker media-proxy traffic or paid Cloudflare features.

## Testing

- mise exec -- pnpm exec playwright test e2e/specs/public/taxonomy-rendering.spec.ts
- mise exec -- pnpm exec playwright test e2e/specs/public/cache-invalidation.spec.ts
- mise exec -- pnpm run ci

The full run passed 88 unit tests, 6 static browser tests, typechecks, build and Worker smoke checks, and 21 Worker-backed browser tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Site favicons configured in settings now appear correctly on public pages.
  * Favicon links use the public media URL for improved accessibility and delivery.
* **Bug Fixes**
  * Improved category and topic archive navigation and link behavior.
  * Updated taxonomy, sitemap, manifest, and favicon rendering to use current site settings.
* **Tests**
  * Added coverage for favicon loading and expanded taxonomy archive validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->