### PR TITLE
Use native EmDash publication timestamps

### DIFF
--- a/.emdash/seed.json
+++ b/.emdash/seed.json
@@ -145,11 +145,6 @@
 					"type": "image"
 				},
 				{
-					"slug": "published_on",
-					"label": "Published On",
-					"type": "datetime"
-				},
-				{
 					"slug": "author_name",
 					"label": "Author Name",
 					"type": "string"
@@ -211,11 +206,6 @@
 					"label": "Menu Order",
 					"type": "integer",
 					"defaultValue": 0
-				},
-				{
-					"slug": "published_on",
-					"label": "Published On",
-					"type": "datetime"
 				},
 				{
 					"slug": "author_name",

--- a/docs/emdash-customizations.md
+++ b/docs/emdash-customizations.md
@@ -108,12 +108,12 @@ consuming the smaller KV write budget or requiring a paid service.
 
 EmDash system properties use camelCase (`createdAt`, `updatedAt`, and
 `publishedAt`). Imported WordPress fields retain their persisted schema slugs,
-which use snake_case (`published_on`, `featured_image`, `author_name`, and
-`menu_order`). These names are database and admin-schema identifiers, not a
-style choice in new application code. New application-facing APIs should use
-camelCase and keep legacy names inside content adapters. Renaming a persisted
-field requires a backup-backed content/schema migration and should be handled
-separately from routine refactoring.
+which use snake_case (`featured_image`, `author_name`, and `menu_order`). These
+names are database and admin-schema identifiers, not a style choice in new
+application code. New application-facing APIs should use camelCase and keep
+legacy names inside content adapters. Renaming a persisted field requires a
+backup-backed content/schema migration and should be handled separately from
+routine refactoring.
 
 ## Cloudflare Access Invites
 

--- a/e2e/specs/public/taxonomy-rendering.spec.ts
+++ b/e2e/specs/public/taxonomy-rendering.spec.ts
@@ -83,6 +83,14 @@ test("renders taxonomy terms hydrated onto public entries", async ({
 				.locator("#content")
 				.getByRole("link", { name: postTitle, exact: true }),
 		).toHaveAttribute("href", post.publicPath);
+		await expect(
+			publicPage.locator("#recent-posts-2 li").filter({
+				has: publicPage.getByRole("link", {
+					name: postTitle,
+					exact: true,
+				}),
+			}),
+		).toContainText(`${postTitle} July 25, 2026`);
 
 		await publicPage.goto(project.publicPath, {
 			waitUntil: "domcontentloaded",

--- a/e2e/specs/public/taxonomy-rendering.spec.ts
+++ b/e2e/specs/public/taxonomy-rendering.spec.ts
@@ -83,14 +83,28 @@ test("renders taxonomy terms hydrated onto public entries", async ({
 				.locator("#content")
 				.getByRole("link", { name: postTitle, exact: true }),
 		).toHaveAttribute("href", post.publicPath);
-		await expect(
-			publicPage.locator("#recent-posts-2 li").filter({
-				has: publicPage.getByRole("link", {
-					name: postTitle,
-					exact: true,
-				}),
+		const recentInterview = publicPage.locator("#recent-posts-2 li").filter({
+			has: publicPage.getByRole("link", {
+				name: postTitle,
+				exact: true,
 			}),
-		).toContainText(`${postTitle} July 25, 2026`);
+		});
+		const recentInterviewLink = recentInterview.getByRole("link", {
+			name: postTitle,
+			exact: true,
+		});
+		const recentInterviewDate = recentInterview.locator(".post-date");
+		await expect(recentInterview).toContainText(`${postTitle} July 25, 2026`);
+		await expect(recentInterviewDate).toHaveCSS("display", "block");
+		const [linkFontSize, dateFontSize] = await Promise.all([
+			recentInterviewLink.evaluate((element) =>
+				Number.parseFloat(getComputedStyle(element).fontSize),
+			),
+			recentInterviewDate.evaluate((element) =>
+				Number.parseFloat(getComputedStyle(element).fontSize),
+			),
+		]);
+		expect(dateFontSize).toBeLessThan(linkFontSize);
 
 		await publicPage.goto(project.publicPath, {
 			waitUntil: "domcontentloaded",

--- a/e2e/support/content.ts
+++ b/e2e/support/content.ts
@@ -117,12 +117,7 @@ export function publicPathForItem(
 		return `/${storedPath || `project/${slug}`}/`;
 	}
 
-	const publishedOn =
-		typeof item.data.published_on === "string" ? item.data.published_on : null;
-	const parts =
-		dateParts(publishedOn) ??
-		dateParts(item.publishedAt) ??
-		dateParts(item.createdAt);
+	const parts = dateParts(item.publishedAt) ?? dateParts(item.createdAt);
 	return `/${storedPath || [...(parts ?? []), slug].join("/")}/`;
 }
 

--- a/emdash-env.d.ts
+++ b/emdash-env.d.ts
@@ -39,7 +39,6 @@ export interface Post {
   excerpt?: PortableTextBlock[];
   content?: PortableTextBlock[];
   featured_image?: { id: string; src?: string; alt?: string; width?: number; height?: number; provider?: string; previewUrl?: string; meta?: Record<string, unknown> };
-  published_on?: string;
   author_name?: string;
   legacy_wp_id?: number;
   createdAt: Date;
@@ -60,7 +59,6 @@ export interface Project {
   featured_image?: { id: string; src?: string; alt?: string; width?: number; height?: number; provider?: string; previewUrl?: string; meta?: Record<string, unknown> };
   highlight?: boolean;
   menu_order?: number;
-  published_on?: string;
   author_name?: string;
   legacy_wp_id?: number;
   createdAt: Date;

--- a/src/components/ThemeSidebar.astro
+++ b/src/components/ThemeSidebar.astro
@@ -12,7 +12,7 @@ const { entries: recentPosts } = await getRecentPosts();
 			{
 				recentPosts.map((post) => (
 					<li>
-						<a href={`/${post.data.path}/`}>{post.data.title}</a>
+						<a href={`/${post.data.path}/`}>{post.data.title}</a>{" "}
 						<span class="post-date">{formatPathDate(post.data.path)}</span>
 					</li>
 				))

--- a/src/lib/content-paths.ts
+++ b/src/lib/content-paths.ts
@@ -48,7 +48,6 @@ export function derivePagePath(path?: string | null, slug?: string | null) {
 export function derivePostPath(
 	path?: string | null,
 	slug?: string | null,
-	publishedOn?: DateValue,
 	publishedAt?: DateValue,
 	createdAt?: DateValue,
 ) {
@@ -58,7 +57,6 @@ export function derivePostPath(
 
 	const dateParts =
 		datePartsFromPath(normalizedPath) ??
-		datePartsFromValue(publishedOn) ??
 		datePartsFromValue(publishedAt) ??
 		datePartsFromValue(createdAt);
 

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -88,8 +88,8 @@ function normalizeEntry<T extends { featured_image?: RawMediaField | null }>(
 	} as NormalizedEntryData<T> & {
 		path?: string;
 		slug?: string;
-		publishedAt?: Date | string | null;
-		createdAt?: Date | string | null;
+		publishedAt?: Date | null;
+		createdAt?: Date | null;
 	};
 
 	if (collection === "pages") {

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -88,7 +88,6 @@ function normalizeEntry<T extends { featured_image?: RawMediaField | null }>(
 	} as NormalizedEntryData<T> & {
 		path?: string;
 		slug?: string;
-		published_on?: string;
 		publishedAt?: Date | string | null;
 		createdAt?: Date | string | null;
 	};
@@ -99,7 +98,6 @@ function normalizeEntry<T extends { featured_image?: RawMediaField | null }>(
 		data.path = derivePostPath(
 			data.path,
 			data.slug || entry.id,
-			data.published_on,
 			data.publishedAt,
 			data.createdAt,
 		);
@@ -180,7 +178,7 @@ export async function getPublishedEntriesByIds<C extends SiteCollection>(
 export function getRecentPosts(limit = 25) {
 	return getPublishedCollectionPage("posts", {
 		limit,
-		orderBy: { published_on: "desc", title: "asc" },
+		orderBy: { published_at: "desc", title: "asc" },
 	});
 }
 
@@ -188,7 +186,7 @@ export function getHighlightedProjects(limit = 6) {
 	return getPublishedCollectionPage("projects", {
 		limit,
 		where: { highlight: "1" },
-		orderBy: { menu_order: "asc", published_on: "desc", title: "asc" },
+		orderBy: { menu_order: "asc", published_at: "desc", title: "asc" },
 	});
 }
 
@@ -197,7 +195,7 @@ export function getPostsPageByCategory(slug: string, page: number, limit = 10) {
 		limit,
 		offset: Math.max(0, page - 1) * limit,
 		where: { category: slug },
-		orderBy: { published_on: "desc", title: "asc" },
+		orderBy: { published_at: "desc", title: "asc" },
 	});
 }
 
@@ -211,7 +209,7 @@ export function getProjectsPageByTaxonomy(
 		limit,
 		offset: Math.max(0, page - 1) * limit,
 		where: { [taxonomy]: slug },
-		orderBy: { menu_order: "asc", published_on: "desc", title: "asc" },
+		orderBy: { menu_order: "asc", published_at: "desc", title: "asc" },
 	});
 }
 

--- a/src/lib/page-context.ts
+++ b/src/lib/page-context.ts
@@ -41,10 +41,6 @@ function toIsoDate(value?: Date | string | null) {
 	return Number.isNaN(date.valueOf()) ? null : date.toISOString();
 }
 
-function getLegacyPublishedOn(data: SiteContentData) {
-	return "published_on" in data ? data.published_on : undefined;
-}
-
 function absoluteCanonical(value: string | null, siteUrl: string) {
 	if (!value) return null;
 	try {
@@ -128,9 +124,7 @@ export function createSitePageContext({
 		},
 		articleMeta: article
 			? {
-					publishedTime: toIsoDate(
-						data.publishedAt || getLegacyPublishedOn(data),
-					),
+					publishedTime: toIsoDate(data.publishedAt),
 					modifiedTime: toIsoDate(data.updatedAt),
 					author: data.author_name || null,
 				}

--- a/src/lib/path-utils.ts
+++ b/src/lib/path-utils.ts
@@ -2,27 +2,6 @@ export function joinPath(parts: string[]) {
 	return parts.filter(Boolean).join("/");
 }
 
-export function sortByPublishedOn<
-	T extends { data: { published_on?: string; title?: string } },
->(items: T[]) {
-	return [...items].sort((a, b) => {
-		const orderA =
-			"menu_order" in a.data && typeof a.data.menu_order === "number"
-				? a.data.menu_order
-				: 0;
-		const orderB =
-			"menu_order" in b.data && typeof b.data.menu_order === "number"
-				? b.data.menu_order
-				: 0;
-		if (orderA !== orderB) return orderA - orderB;
-
-		const dateA = a.data.published_on ? Date.parse(a.data.published_on) : 0;
-		const dateB = b.data.published_on ? Date.parse(b.data.published_on) : 0;
-		if (dateA !== dateB) return dateB - dateA;
-		return (a.data.title ?? "").localeCompare(b.data.title ?? "");
-	});
-}
-
 export function ensureTrailingSlash(value: string) {
 	if (value === "/") return value;
 	return value.endsWith("/") ? value : `${value}/`;

--- a/src/lib/sitemap.ts
+++ b/src/lib/sitemap.ts
@@ -7,18 +7,11 @@ const APOS_RE = /'/g;
 export interface SitemapInputEntry {
 	id: string;
 	image?: string | null;
-	updated_at?: string | null;
-	updatedAt?: string | Date | null;
-	published_at?: string | null;
-	publishedAt?: string | Date | null;
-	createdAt?: string | Date | null;
 	data: {
 		path?: string | null;
-		updated_at?: string | null;
 		updatedAt?: string | Date | null;
-		published_at?: string | null;
 		publishedAt?: string | Date | null;
-		published_on?: string | null;
+		createdAt?: string | Date | null;
 		seo?: {
 			canonical?: string | null;
 			noIndex?: boolean;
@@ -76,16 +69,9 @@ function timestampValue(value?: string | Date | null) {
 
 export function sitemapEntryLastmod(entry: SitemapInputEntry) {
 	return (
-		timestampValue(entry.updated_at) ||
-		timestampValue(entry.updatedAt) ||
-		timestampValue(entry.data.updated_at) ||
 		timestampValue(entry.data.updatedAt) ||
-		timestampValue(entry.published_at) ||
-		timestampValue(entry.publishedAt) ||
-		timestampValue(entry.data.published_at) ||
 		timestampValue(entry.data.publishedAt) ||
-		timestampValue(entry.data.published_on) ||
-		timestampValue(entry.createdAt)
+		timestampValue(entry.data.createdAt)
 	);
 }
 

--- a/src/pages/[year]/[month]/[day]/[slug].astro
+++ b/src/pages/[year]/[month]/[day]/[slug].astro
@@ -32,11 +32,7 @@ const categories = post.data.terms?.category ?? [];
 						{post.data.title}
 					</h1>
 					<div class="entry-meta">
-						{
-							post.data.published_on
-								? new Date(post.data.published_on).toLocaleDateString()
-								: ""
-						}
+						{post.data.publishedAt?.toLocaleDateString() ?? ""}
 					</div>
 				</header>
 				<div class="entry-content" {...post.edit.content}>

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -19,11 +19,6 @@ import {
 
 interface SitemapSourceEntry {
 	id: string;
-	updated_at?: string | null;
-	updatedAt?: string | Date | null;
-	published_at?: string | null;
-	publishedAt?: string | Date | null;
-	createdAt?: string | Date | null;
 	data: Omit<SitemapInputEntry["data"], "seo"> & { seo?: ContentSeo };
 }
 
@@ -34,18 +29,11 @@ function toSitemapEntry(
 	return {
 		id: entry.id,
 		image: getSeoMeta(entry, { siteUrl }).ogImage,
-		updated_at: entry.updated_at,
-		updatedAt: entry.updatedAt,
-		published_at: entry.published_at,
-		publishedAt: entry.publishedAt,
-		createdAt: entry.createdAt,
 		data: {
 			path: entry.data.path,
-			updated_at: entry.data.updated_at,
 			updatedAt: entry.data.updatedAt,
-			published_at: entry.data.published_at,
 			publishedAt: entry.data.publishedAt,
-			published_on: entry.data.published_on,
+			createdAt: entry.data.createdAt,
 			seo: entry.data.seo,
 		},
 	};

--- a/src/scss/_sidebar.scss
+++ b/src/scss/_sidebar.scss
@@ -123,6 +123,14 @@
 	text-decoration: underline;
 }
 
+.widget_recent_entries .post-date {
+	display: block;
+	margin-top: 0.2rem;
+	color: $gray;
+	font-size: 0.8rem;
+	line-height: 1.4;
+}
+
 // Specific widget types - more specific selectors come after general ones
 .widget_archive ul li,
 .widget_categories ul li {

--- a/tests/unit/content-paths.test.ts
+++ b/tests/unit/content-paths.test.ts
@@ -22,7 +22,7 @@ describe("content path derivation", () => {
 		).toBe("about-ce-projects/leaf");
 	});
 
-	test("derives dated post paths from path, published, and created dates", () => {
+	test("derives dated post paths from path and native publication dates", () => {
 		expect(derivePostPath("2022/05/31/jason-swartwood", "updated-post")).toBe(
 			"2022/05/31/updated-post",
 		);
@@ -33,16 +33,10 @@ describe("content path derivation", () => {
 			"2026/05/31/new-post",
 		);
 		expect(
-			derivePostPath(null, "published-post", null, "2025-04-03T11:00:00.000Z"),
+			derivePostPath(null, "published-post", "2025-04-03T11:00:00.000Z"),
 		).toBe("2025/04/03/published-post");
 		expect(
-			derivePostPath(
-				null,
-				"created-post",
-				null,
-				null,
-				"2024-03-02T11:00:00.000Z",
-			),
+			derivePostPath(null, "created-post", null, "2024-03-02T11:00:00.000Z"),
 		).toBe("2024/03/02/created-post");
 		expect(derivePostPath(null, "undated-post")).toBe("undated-post");
 	});

--- a/tests/unit/content-retrieval-and-taxonomy.test.ts
+++ b/tests/unit/content-retrieval-and-taxonomy.test.ts
@@ -48,7 +48,7 @@ describe("content retrieval and taxonomy", () => {
 			limit: 10,
 			offset: 20,
 			where: { category: "news" },
-			orderBy: { published_on: "desc", title: "asc" },
+			orderBy: { published_at: "desc", title: "asc" },
 		});
 		expect(result).toMatchObject({
 			hasMore: true,
@@ -68,7 +68,7 @@ describe("content retrieval and taxonomy", () => {
 		expect(getEmDashCollection).toHaveBeenCalledWith("posts", {
 			status: "published",
 			limit: 25,
-			orderBy: { published_on: "desc", title: "asc" },
+			orderBy: { published_at: "desc", title: "asc" },
 		});
 	});
 

--- a/tests/unit/page-context.test.ts
+++ b/tests/unit/page-context.test.ts
@@ -61,12 +61,12 @@ describe("site page context", () => {
 		expect(page.title).toBe("Engaged Philosophy – Philosophy in practice");
 	});
 
-	test("uses EmDash SEO fields and legacy publication metadata", () => {
+	test("uses EmDash SEO fields and native publication metadata", () => {
 		const entry = postEntry({
 			id: "content-id",
 			slug: "an-essay",
 			title: "An essay",
-			published_on: "2026-07-01T10:00:00Z",
+			publishedAt: new Date("2026-07-01T10:00:00Z"),
 			updatedAt: new Date("2026-07-02T11:00:00Z"),
 			author_name: "A. Philosopher",
 			seo: {

--- a/tests/unit/sitemap.test.ts
+++ b/tests/unit/sitemap.test.ts
@@ -39,10 +39,10 @@ describe("sitemap helpers", () => {
 		expect(
 			sitemapEntryLastmod({
 				id: "post",
-				updatedAt: new Date("2026-06-07T00:00:00Z"),
 				data: {
 					path: "2022/05/31/jason-swartwood",
-					published_on: "2022-06-01T00:12:21Z",
+					updatedAt: new Date("2026-06-07T00:00:00Z"),
+					publishedAt: new Date("2022-06-01T00:12:21Z"),
 				},
 			}),
 		).toBe("2026-06-07T00:00:00.000Z");
@@ -52,31 +52,31 @@ describe("sitemap helpers", () => {
 				id: "page",
 				data: {
 					path: "about",
-					updatedAt: new Date("2026-06-07T00:00:00Z"),
+					publishedAt: new Date("2022-06-01T00:12:21Z"),
 				},
 			}),
-		).toBe("2026-06-07T00:00:00.000Z");
+		).toBe("2022-06-01T00:12:21.000Z");
 	});
 
 	test("renders unique XML sitemap URLs with escaped values", () => {
 		const xml = renderSitemapXml("https://www.engagedphilosophy.com", [
 			{
 				id: "home",
-				data: { path: "", updated_at: "2026-06-07T00:00:00Z" },
+				data: { path: "", updatedAt: "2026-06-07T00:00:00Z" },
 			},
 			{
 				id: "project",
 				image: "https://media.example/project&image.jpg",
 				data: {
 					path: "project/a-b",
-					updated_at: "2026-06-07T00:00:00Z",
+					updatedAt: "2026-06-07T00:00:00Z",
 				},
 			},
 			{
 				id: "duplicate",
 				data: {
 					path: "project/a-b",
-					updated_at: "2026-06-08T00:00:00Z",
+					updatedAt: "2026-06-08T00:00:00Z",
 				},
 			},
 		]);


### PR DESCRIPTION
## Summary

- use EmDash native publication timestamps for archive ordering, post dates and paths, article metadata, and sitemap timestamps
- remove legacy publication fallbacks and the unused in-memory legacy sorter
- remove the `published_on` fields from the seed schema and regenerated EmDash types
- display Recent Interviews dates below their titles in smaller, muted text

## Production data migration

Before changing the code, I created a private selective D1 backup and verified that it restores with matching content/schema row counts. A full Wrangler export is not possible because the production database contains FTS5 virtual tables, so the backup excludes only rebuildable search-index tables.

All 76 published posts and 137 published projects already had native `published_at` values matching their valid legacy values. Of the drafts, only `journaling-for-mental-health` had a real legacy publication date; its native value was backfilled and verified. The other 20 draft values are WordPress `0000-00-00T00:00:00Z` sentinels and were intentionally left unpublished.

The production `published_on` schema fields/columns must remain until this PR is deployed because the current production code still reads them. They can be removed through EmDash after deployment and a final production verification.

## Tests

- `pnpm run ci`
- `pnpm exec playwright test e2e/specs/public/taxonomy-rendering.spec.ts`
- `pnpm run typecheck`
- `pnpm run typecheck:tests`
- `pnpm run lint:eslint`
- `pnpm run lint:css`

The full CI run includes 88 unit tests, 6 static browser tests, generated EmDash type verification, Astro and test typechecks, the production build, Worker bundle/runtime smoke tests, and 21 Worker-backed browser tests.