### PR TITLE
Remove obsolete featured-image compatibility

### DIFF
--- a/docs/emdash-customizations.md
+++ b/docs/emdash-customizations.md
@@ -81,6 +81,10 @@ consuming the smaller KV write budget or requiring a paid service.
   small screens. Migrated images keep their reliable source width but omit
   unreliable imported heights, so they render directly from the public R2
   domain instead of consuming Cloudflare image transformations.
+- Featured images use EmDash's native local-media metadata. The public content
+  adapter maps each storage key directly to the public R2 domain once, so
+  homepage, archive, and search renderers can use the normalized URL without
+  retaining older seed-media shapes or repeating WordPress URL rewrites.
 - Portable Text galleries delegate their markup, image loading, and captions to
   EmDash, and EmDash 0.31 keeps those native gallery blocks visible and editable
   in the admin editor. A small public-rendering adapter resolves migrated image

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -29,10 +29,11 @@ browser timing in `e2e-static/`, and admin/public workflows in `e2e/`.
 - `pnpm run test:e2e` runs the Worker-backed Playwright suite.
 - `pnpm run test:e2e:admin`, `pnpm run test:e2e:editing`, and
   `pnpm run test:e2e:public` run focused Worker-backed Playwright groups.
-- `pnpm run smoke:live` runs lightweight checks against a deployed site. Set
-  `LIVE_BASE_URL` to target a non-default hostname. The smoke test requests one
-  public page twice and requires Cloudflare's second response to report a cache
-  hit (or a stale/revalidated equivalent).
+- `pnpm run smoke:live` runs lightweight checks against
+  `https://www.engagedphilosophy.com`. Set `LIVE_BASE_URL` to target another
+  deployment. The smoke test requests one public page twice and requires
+  Cloudflare's second response to report a cache hit (or a stale/revalidated
+  equivalent).
 - `pnpm run smoke:live:sitemap` runs the deployed smoke checks plus every same
   origin URL listed in the sitemap, and fails if the sitemap is empty.
 - Use `LIVE_SMOKE_PATH_FILE` with `pnpm run smoke:live` to check one URL/path

--- a/scripts/test-smoke-live.mjs
+++ b/scripts/test-smoke-live.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import fs from "node:fs";
 
-const DEFAULT_BASE_URL = "https://engaged-philosophy.ramona75.workers.dev";
+const DEFAULT_BASE_URL = "https://www.engagedphilosophy.com";
 const REQUEST_TIMEOUT_MS = Number.parseInt(
 	process.env.LIVE_SMOKE_TIMEOUT_MS ?? "12000",
 	10,

--- a/src/components/TaxonomyArchive.astro
+++ b/src/components/TaxonomyArchive.astro
@@ -7,7 +7,6 @@ import {
 	getEntryExcerpt,
 	getExcerptText,
 } from "../lib/rich-text";
-import { getMediaUrlPrefix, rewriteWordPressUploadUrl } from "../lib/media";
 import type { ContentEntry, ProjectData } from "../lib/types";
 
 interface Props {
@@ -24,7 +23,6 @@ const hasResults = projects.length > 0;
 const showSidebar = taxonomy !== "topic";
 const titlePrefix = taxonomy === "topic" ? "Project Topic: " : "";
 const basePath = `/${taxonomy}/${Astro.params.slug}/`;
-const mediaUrlPrefix = getMediaUrlPrefix();
 
 function pageHref(pageNumber: number) {
 	return pageNumber === 1 ? basePath : `${basePath}page/${pageNumber}/`;
@@ -51,12 +49,7 @@ function pageHref(pageNumber: number) {
 							getEntryContent(project.data),
 						)}
 						image={{
-							src: project.data.featured_image?.src
-								? rewriteWordPressUploadUrl(
-										project.data.featured_image.src,
-										mediaUrlPrefix,
-									)
-								: undefined,
+							src: project.data.featured_image?.src,
 							alt: project.data.featured_image?.alt || project.data.title,
 						}}
 					/>

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -13,7 +13,7 @@ import {
 	normalizeContentPath,
 	slugFromPath,
 } from "./content-paths";
-import { getPublicMediaStorageUrl, rewriteInternalMediaFileUrl } from "./media";
+import { getPublicMediaStorageUrl } from "./media";
 import type {
 	ContentEntry,
 	MediaField,
@@ -32,50 +32,22 @@ type NormalizedEntryData<T> = Omit<T, "featured_image"> & {
 };
 type RawMediaField = MediaField & {
 	provider?: string;
-	id?: string;
 	meta?: {
 		storageKey?: string;
-	};
-	$media?: {
-		url?: string;
-		alt?: string;
 	};
 };
 
 const COLLECTION_PAGE_SIZE = 1000;
 
-function normalizeLocalMediaField(
-	media: RawMediaField,
+function normalizeMediaField(
+	media?: RawMediaField | null,
 ): MediaField | undefined {
-	if (media.provider !== "local" || !media.meta?.storageKey) return undefined;
+	if (media?.provider !== "local" || !media.meta?.storageKey) return undefined;
 
 	return {
 		src: getPublicMediaStorageUrl(media.meta.storageKey),
 		alt: media.alt,
 	};
-}
-
-function normalizeSeedMediaFallback(
-	media: RawMediaField,
-): MediaField | undefined {
-	// Compatibility for older generated seed data. Current imports emit local
-	// EmDash media values before content reaches runtime.
-	if (!media.$media?.url) return undefined;
-	return {
-		src: rewriteInternalMediaFileUrl(media.$media.url),
-		alt: media.$media.alt,
-	};
-}
-
-function normalizeMediaField(
-	media?: RawMediaField | null,
-): MediaField | undefined {
-	if (!media) return undefined;
-	const localMedia = normalizeLocalMediaField(media);
-	if (localMedia) return localMedia;
-	if (media.src)
-		return { src: rewriteInternalMediaFileUrl(media.src), alt: media.alt };
-	return normalizeSeedMediaFallback(media);
 }
 
 function normalizeEntry<T extends { featured_image?: RawMediaField | null }>(

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -1,7 +1,6 @@
 import { search as searchEmDash } from "emdash";
 
 import { getPublishedEntriesByIds } from "./content";
-import { rewriteWordPressUploadUrl } from "./media";
 import {
 	getEntryContent,
 	getEntryExcerpt,
@@ -62,7 +61,6 @@ export function isValidSearchCursorHistory(
 export async function searchSite(
 	rawQuery: string,
 	cursor?: string,
-	mediaUrlPrefix = "",
 ): Promise<SiteSearchResponse> {
 	const query = rawQuery.trim();
 	if (!query) return { query, results: [] };
@@ -110,10 +108,7 @@ export async function searchSite(
 					getEntryExcerpt(entry.data),
 					getEntryContent(entry.data),
 				),
-				imageSrc: rewriteWordPressUploadUrl(
-					entry.data.featured_image?.src,
-					mediaUrlPrefix,
-				),
+				imageSrc: entry.data.featured_image?.src,
 			},
 		];
 	});

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,7 +4,6 @@ import SearchResults from "../components/SearchResults.astro";
 import Base from "../layouts/Base.astro";
 import { getHighlightedProjects, getPageBySlug } from "../lib/content";
 import { searchSite } from "../lib/search";
-import { getMediaUrlPrefix, rewriteWordPressUploadUrl } from "../lib/media";
 import {
 	getEntryContent,
 	getEntryExcerpt,
@@ -14,10 +13,7 @@ import {
 const home = await getPageBySlug("home");
 const { entries: highlightedProjects } = await getHighlightedProjects();
 const query = Astro.url.searchParams.get("s")?.trim() ?? "";
-const mediaUrlPrefix = getMediaUrlPrefix();
-const search = query
-	? await searchSite(query, undefined, mediaUrlPrefix)
-	: null;
+const search = query ? await searchSite(query) : null;
 const homeEntryAttrs = home?.edit ?? {};
 const homeBoxes = home
 	? [
@@ -69,10 +65,7 @@ const homeBoxes = home
 									<div class:list={["carousel-item", index === 0 && "active"]}>
 										{project.data.featured_image?.src && (
 											<img
-												src={rewriteWordPressUploadUrl(
-													project.data.featured_image.src,
-													mediaUrlPrefix,
-												)}
+												src={project.data.featured_image.src}
 												alt={`${project.data.title} project image`}
 												width="700"
 												height="460"

--- a/src/pages/page/[page].astro
+++ b/src/pages/page/[page].astro
@@ -2,7 +2,6 @@
 import SearchResults from "../../components/SearchResults.astro";
 import Base from "../../layouts/Base.astro";
 import { isValidSearchCursorHistory, searchSite } from "../../lib/search";
-import { getMediaUrlPrefix } from "../../lib/media";
 import { InvalidCursorError } from "emdash";
 
 const pageNumber = Number(Astro.params.page ?? "1");
@@ -20,10 +19,9 @@ if (
 	return Astro.redirect("/404");
 }
 
-const mediaUrlPrefix = getMediaUrlPrefix();
 let search;
 try {
-	search = await searchSite(query, cursor, mediaUrlPrefix);
+	search = await searchSite(query, cursor);
 } catch (error) {
 	if (!(error instanceof InvalidCursorError)) throw error;
 	return Astro.redirect("/404");

--- a/tests/unit/content-retrieval-and-taxonomy.test.ts
+++ b/tests/unit/content-retrieval-and-taxonomy.test.ts
@@ -72,6 +72,40 @@ describe("content retrieval and taxonomy", () => {
 		});
 	});
 
+	test("serves native local featured images from public storage", async () => {
+		getEmDashCollection.mockResolvedValue({
+			entries: [
+				entry("post-1", {
+					slug: "first-post",
+					path: "2026/01/02/first-post",
+					title: "First post",
+					featured_image: {
+						provider: "local",
+						meta: {
+							storageKey: "wp-content/uploads/2026/01/featured.jpg",
+						},
+						alt: "Featured",
+					},
+				}),
+			],
+			hasMore: false,
+			cacheHint: {},
+		});
+
+		await expect(getRecentPosts(1)).resolves.toMatchObject({
+			entries: [
+				{
+					data: {
+						featured_image: {
+							src: "https://media.engagedphilosophy.com/wp-content/uploads/2026/01/featured.jpg",
+							alt: "Featured",
+						},
+					},
+				},
+			],
+		});
+	});
+
 	test("walks collection cursors instead of truncating full listings", async () => {
 		getEmDashCollection
 			.mockResolvedValueOnce({

--- a/tests/unit/search.test.ts
+++ b/tests/unit/search.test.ts
@@ -48,6 +48,10 @@ describe("site search", () => {
 								id: "project-1",
 								title: "Project One",
 								path: "project/project-one",
+								featured_image: {
+									src: "https://media.example.com/project-one.jpg",
+									alt: "Project One",
+								},
 							},
 						},
 					];
@@ -62,11 +66,7 @@ describe("site search", () => {
 			},
 		);
 
-		const result = await searchSite(
-			"community",
-			"current-page",
-			"https://media.example.com",
-		);
+		const result = await searchSite("community", "current-page");
 
 		expect(emdashSearch).toHaveBeenCalledWith("community", {
 			collections: ["pages", "posts", "projects"],
@@ -83,6 +83,7 @@ describe("site search", () => {
 					kind: "project",
 					title: "Project One",
 					path: "project/project-one",
+					imageSrc: "https://media.example.com/project-one.jpg",
 				},
 				{
 					id: "page-1",


### PR DESCRIPTION
## Summary

- normalize featured images only from EmDash native local-media metadata and remove legacy generated-seed/src-only fallbacks
- use the normalized public-R2 URL directly in homepage, taxonomy archive, and search rendering
- point the live smoke command at the routed production custom domain instead of the inactive workers.dev hostname

## Production audit

Before this change, the production D1 audit found 268 entries and 134 featured images. All 134 featured images use provider=local with a non-empty meta.storageKey; none use the old $media seed shape or a stored src-only shape.

The central Portable Text/media resolver remains unchanged for legacy videos, galleries, and links. Featured media still uses direct public R2 delivery to avoid Worker media-proxy requests on Cloudflare Workers Free.

## Tests

- mise exec -- pnpm run ci
- mise exec -- pnpm run smoke:live

The full CI suite passed: 89 unit tests, 6 static-browser tests, type and generated-schema checks, production build and Worker checks, and 21 Worker-backed browser tests. The production live smoke passed for public routes, cache behavior, favicon/manifest, and the Access-protected admin route.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Featured images now render consistently across the homepage, archives, and search using public media URLs.
  * Search results and project listings display featured images without legacy URL transformations.
  * Local media metadata preserves image descriptions and resolves storage keys to public URLs.

* **Documentation**
  * Clarified featured-image rendering and media URL behavior.
  * Updated live smoke-test instructions, including the default site URL and cache-hit verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->