### PR TITLE
Use native EmDash bylines

### DIFF
--- a/.emdash/seed.json
+++ b/.emdash/seed.json
@@ -94,11 +94,6 @@
 					"widget": "portableText"
 				},
 				{
-					"slug": "author_name",
-					"label": "Author Name",
-					"type": "string"
-				},
-				{
 					"slug": "legacy_wp_id",
 					"label": "Legacy WordPress ID",
 					"type": "integer"
@@ -143,11 +138,6 @@
 					"slug": "featured_image",
 					"label": "Featured Image",
 					"type": "image"
-				},
-				{
-					"slug": "author_name",
-					"label": "Author Name",
-					"type": "string"
 				},
 				{
 					"slug": "legacy_wp_id",
@@ -206,11 +196,6 @@
 					"label": "Menu Order",
 					"type": "integer",
 					"defaultValue": 0
-				},
-				{
-					"slug": "author_name",
-					"label": "Author Name",
-					"type": "string"
 				},
 				{
 					"slug": "legacy_wp_id",

--- a/docs/emdash-customizations.md
+++ b/docs/emdash-customizations.md
@@ -100,6 +100,9 @@ consuming the smaller KV write budget or requiring a paid service.
   for standard blocks. The site adapter only preserves the imported image-alt
   and gallery-caption fallback behavior that EmDash cannot infer from the
   nested legacy gallery shape.
+- Article author metadata uses the primary credit from EmDash's hydrated
+  `data.bylines`. Imported WordPress author values were migrated to native
+  byline profiles and credits, so there is no separate author field adapter.
 - Legacy renderers remain for Animoto embeds, playlist videos, and dynamic page
   lists. EmDash does not support Animoto or the page-list behavior. Its
   self-hosted embed currently forces videos into 16:9 and omits intrinsic
@@ -112,12 +115,12 @@ consuming the smaller KV write budget or requiring a paid service.
 
 EmDash system properties use camelCase (`createdAt`, `updatedAt`, and
 `publishedAt`). Imported WordPress fields retain their persisted schema slugs,
-which use snake_case (`featured_image`, `author_name`, and `menu_order`). These
-names are database and admin-schema identifiers, not a style choice in new
-application code. New application-facing APIs should use camelCase and keep
-legacy names inside content adapters. Renaming a persisted field requires a
-backup-backed content/schema migration and should be handled separately from
-routine refactoring.
+which use snake_case (`featured_image` and `menu_order`). These names are
+database and admin-schema identifiers, not a style choice in new application
+code. New application-facing APIs should use camelCase and keep legacy names
+inside content adapters. Renaming a persisted field requires a backup-backed
+content/schema migration and should be handled separately from routine
+refactoring.
 
 ## Cloudflare Access Invites
 

--- a/emdash-env.d.ts
+++ b/emdash-env.d.ts
@@ -21,7 +21,6 @@ export interface Page {
   box_middle_html?: PortableTextBlock[];
   box_right_title?: string;
   box_right_html?: PortableTextBlock[];
-  author_name?: string;
   legacy_wp_id?: number;
   createdAt: Date;
   updatedAt: Date;
@@ -39,7 +38,6 @@ export interface Post {
   excerpt?: PortableTextBlock[];
   content?: PortableTextBlock[];
   featured_image?: { id: string; src?: string; alt?: string; width?: number; height?: number; provider?: string; previewUrl?: string; meta?: Record<string, unknown> };
-  author_name?: string;
   legacy_wp_id?: number;
   createdAt: Date;
   updatedAt: Date;
@@ -59,7 +57,6 @@ export interface Project {
   featured_image?: { id: string; src?: string; alt?: string; width?: number; height?: number; provider?: string; previewUrl?: string; meta?: Record<string, unknown> };
   highlight?: boolean;
   menu_order?: number;
-  author_name?: string;
   legacy_wp_id?: number;
   createdAt: Date;
   updatedAt: Date;

--- a/src/lib/page-context.ts
+++ b/src/lib/page-context.ts
@@ -126,7 +126,7 @@ export function createSitePageContext({
 			? {
 					publishedTime: toIsoDate(data.publishedAt),
 					modifiedTime: toIsoDate(data.updatedAt),
-					author: data.author_name || null,
+					author: data.bylines?.[0]?.byline.displayName || null,
 				}
 			: undefined,
 		siteName: siteTitle,

--- a/tests/unit/page-context.test.ts
+++ b/tests/unit/page-context.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "vitest";
+import type { ContentBylineCredit } from "emdash";
 
 import {
 	createSitePageContext,
@@ -20,6 +21,28 @@ function postEntry(data: Partial<PostData>): ContentEntry<PostData> {
 			...data,
 		},
 		edit: {} as ContentEntry<PostData>["edit"],
+	};
+}
+
+function bylineCredit(displayName: string): ContentBylineCredit {
+	return {
+		byline: {
+			id: "byline-id",
+			slug: "a-philosopher",
+			displayName,
+			bio: null,
+			avatarMediaId: null,
+			websiteUrl: null,
+			userId: null,
+			isGuest: true,
+			createdAt: "2026-07-01T00:00:00.000Z",
+			updatedAt: "2026-07-01T00:00:00.000Z",
+			locale: "en",
+			translationGroup: "byline-id",
+		},
+		sortOrder: 0,
+		roleLabel: null,
+		source: "explicit",
 	};
 }
 
@@ -68,7 +91,7 @@ describe("site page context", () => {
 			title: "An essay",
 			publishedAt: new Date("2026-07-01T10:00:00Z"),
 			updatedAt: new Date("2026-07-02T11:00:00Z"),
-			author_name: "A. Philosopher",
+			bylines: [bylineCredit("A. Philosopher")],
 			seo: {
 				title: "A better title",
 				description: "A concise description",


### PR DESCRIPTION
## Summary

- read article author metadata from hydrated native EmDash bylines
- remove the legacy author_name field from pages, posts, and projects in the seed schema and generated types
- document native bylines as the source of article authors

## Production migration

- created private D1 backups before each production data change and verified them by restoring clean copies (not committed)
- migrated all 267 author-bearing entries, including drafts, to four native byline profiles
- preserved the existing display names exactly to avoid public metadata changes
- matched the original WordPress accounts to active EmDash users by email, assigning 151 admin entries to ramona75 and 105 mojanzen entries to mojanzen
- linked the admin and Engaged Philosphy byline profiles to those users; Susan Hawthorne and Arjun remain guest bylines because they do not have EmDash users
- verified 267 primary byline assignments, 246 published byline assignments, 256 imported ownership assignments, no unresolved or duplicate credits, no ownership/byline mismatches, and clean D1 integrity/foreign-key checks
- after the merged Worker deployed successfully, removed all three legacy production field definitions and physical author_name columns
- removed obsolete author_name and published_on keys from all 277 revision snapshots so all 24 pending drafts remain publishable with the current schema

## Testing

- mise exec -- pnpm run ci
  - formatting, ESLint, Stylelint
  - 89 unit tests
  - 6 static Playwright tests
  - generated EmDash type check and TypeScript checks
  - 5 seed tests
  - production build and Worker bundle/runtime smoke tests
  - 21 Worker-backed Playwright tests
- post-merge CI and Cloudflare production deployment passed
- production D1 quick check and foreign-key check passed after cleanup
- production live smoke and all 244 sitemap URL checks passed
- uncached native author metadata/JSON-LD and public search checks passed