### PR TITLE
Fix public file links

### DIFF
--- a/scripts/test-smoke-live.mjs
+++ b/scripts/test-smoke-live.mjs
@@ -136,6 +136,11 @@ async function checkPublicPage(path) {
 		false,
 		`Public page ${path} should not advertise the removed SVG favicon`,
 	);
+	assert.equal(
+		/<a\b[^>]*\bhref=["'][^"']*\/_emdash\/api\/media\/file\//i.test(text),
+		false,
+		`Public page ${path} should not link to an Access-protected media route`,
+	);
 
 	console.log(`ok public ${path}`);
 }


### PR DESCRIPTION
## Summary

- migrate 65 legacy file-link occurrences from the Access-protected EmDash media route to the public R2 domain
- restore three missing PDFs from their authoritative sources, upload them to R2, and register them as native EmDash media
- replace the unavailable 2014 PLU poster with a surviving event page
- fail the full-sitemap live smoke check if public anchors point at the protected media route

The production content migration updated 18 entries and their 18 live revisions. A private, restore-tested D1 backup was created before the migration; it is not included in this PR.

## Validation

- `mise exec -- pnpm run ci`
- all 66 protected link occurrences removed from current content and revisions
- 65 occurrences now resolve through `media.engagedphilosophy.com`; one resolves to the surviving 2014 event page
- all three restored R2 objects verified byte-for-byte against their source downloads
- production content/revision JSON valid and live revisions match current content
- production D1 `PRAGMA quick_check`: `ok`
- production D1 `PRAGMA foreign_key_check`: no violations

## Deployment note

The currently deployed version may continue serving previously cached HTML until this PR's deployment changes the Worker cache version. The migrated content is already visible on cache-bypassed requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated live smoke checks to verify that public pages do not expose links to access-protected media routes.
  * Replaced the outdated favicon-related validation with coverage for protected media links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->