### PR TITLE
Fix internal links discovered by the live-site scan

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -10,6 +10,7 @@ import { fileURLToPath } from "node:url";
 import {
 	CLOUDFLARE_ACCESS_TEAM_DOMAIN,
 	PUBLIC_MEDIA_URL,
+	PUBLIC_SITE_URL,
 } from "./src/lib/site-config.ts";
 
 const legacyContentPluginEntrypoint = fileURLToPath(
@@ -62,6 +63,7 @@ export const emdashPlugins = [
 ];
 
 export default defineConfig({
+	site: PUBLIC_SITE_URL,
 	output: "server",
 	adapter: cloudflare({
 		...(emdashTypesCheckState
@@ -95,6 +97,7 @@ export default defineConfig({
 		react(),
 		localEmDashRoutes(),
 		emdash({
+			siteUrl: PUBLIC_SITE_URL,
 			database: d1({ binding: "DB", session: "disabled" }),
 			storage: r2({
 				binding: "MEDIA",

--- a/e2e/specs/public/client-behavior.spec.ts
+++ b/e2e/specs/public/client-behavior.spec.ts
@@ -5,6 +5,17 @@ import {
 	uniqueTitle,
 } from "../../support/content";
 
+test("links skip navigation only to targets present on every page", async ({
+	publicPage,
+}) => {
+	await publicPage.goto("/");
+
+	const skipLinks = publicPage.locator(".skip-link a");
+	await expect(skipLinks).toHaveCount(1);
+	await expect(skipLinks).toHaveAttribute("href", "#content");
+	await expect(publicPage.locator("#content")).toHaveCount(1);
+});
+
 test("uses Bootstrap data APIs for public theme interactions", async ({
 	authedRequest,
 	publicPage,

--- a/e2e/specs/public/feed.spec.ts
+++ b/e2e/specs/public/feed.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from "../../fixtures/worker";
+import {
+	createAndPublishContentViaApi,
+	deleteContentViaApi,
+	uniqueTitle,
+} from "../../support/content";
+
+test("serves published posts through the legacy RSS feed URL", async ({
+	authedRequest,
+	publicPage,
+}, testInfo) => {
+	const title = uniqueTitle("E2E RSS Post", testInfo.testId);
+	const description = "A feed summary generated from portable text.";
+	const { created, publicPath } = await createAndPublishContentViaApi(
+		authedRequest,
+		"posts",
+		{
+			title,
+			content: description,
+			publishedAt: "2026-07-25T12:00:00Z",
+		},
+	);
+
+	try {
+		const response = await publicPage.goto("/feed/");
+		expect(response?.status()).toBe(200);
+		expect(response?.headers()["content-type"]).toContain(
+			"application/rss+xml",
+		);
+		expect(response?.headers()["cache-tag"]).toContain("site-settings");
+		expect(response?.headers()["cache-tag"]).toContain("posts");
+		expect(response?.headers()["cloudflare-cdn-cache-control"]).toContain(
+			"max-age=86400",
+		);
+
+		const xml = await response!.text();
+		expect(xml).toContain("<rss");
+		expect(xml).toContain(`<title>${title}</title>`);
+		expect(xml).toContain(
+			`<link>https://www.engagedphilosophy.com${publicPath}</link>`,
+		);
+		expect(xml).toContain(`<description>${description}</description>`);
+	} finally {
+		await deleteContentViaApi(authedRequest, "posts", created.id);
+	}
+});

--- a/e2e/specs/public/sitemap.spec.ts
+++ b/e2e/specs/public/sitemap.spec.ts
@@ -61,8 +61,16 @@ test.describe("public sitemap", () => {
 		);
 
 		const xml = await response!.text();
+		const locations = parseLocations(xml);
 		const locationPaths = parseLocationPaths(xml);
 
+		expect(locations.length).toBeGreaterThan(0);
+		expect(
+			locations.every(
+				(location) =>
+					new URL(location).origin === "https://www.engagedphilosophy.com",
+			),
+		).toBe(true);
 		expect(locationPaths).toContain(pagePath);
 		expect(locationPaths).toContain(postPath);
 		expect(locationPaths).not.toContain(`/posts/${postSlug}/`);

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
 	"dependencies": {
 		"@astrojs/cloudflare": "^14.1.4",
 		"@astrojs/react": "^6.0.1",
+		"@astrojs/rss": "^4.0.19",
 		"@emdash-cms/auth": "^0.31.1",
 		"@emdash-cms/cloudflare": "^0.31.1",
 		"@emdash-cms/plugin-audit-log": "^0.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
       '@astrojs/react':
         specifier: ^6.0.1
         version: 6.0.1(@types/node@26.1.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.7)(supports-color@10.2.2)(yaml@2.9.0)
+      '@astrojs/rss':
+        specifier: ^4.0.19
+        version: 4.0.19
       '@emdash-cms/auth':
         specifier: ^0.31.1
         version: 0.31.1(astro@7.1.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.1)(rollup@4.62.2)(sass@1.101.7)(yaml@2.9.0))(kysely@0.29.4)
@@ -257,6 +260,9 @@ packages:
       '@types/react-dom': ^17.0.17 || ^18.0.6 || ^19.0.0
       react: ^17.0.2 || ^18.0.0 || ^19.0.0
       react-dom: ^17.0.2 || ^18.0.0 || ^19.0.0
+
+  '@astrojs/rss@4.0.19':
+    resolution: {integrity: sha512-e+z5wYeYtffQdHQO8c2tkSd2JEBdAuRXJV4ZEU5IxkYeE6e39woDd7nw1PH1Kk2tEYNCYuKdylnnbhGmt61awA==}
 
   '@astrojs/telemetry@3.3.3':
     resolution: {integrity: sha512-C1TLn5sPJr0x4vk56piHWKbnqlEB8BKyte5Y45V02U+D7BGO5eMqZDH5aPjnkXQWJggvmsTXxH03QMZ9NgWLzQ==}
@@ -1609,6 +1615,9 @@ packages:
   '@neon-rs/load@0.0.4':
     resolution: {integrity: sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw==}
 
+  '@nodable/entities@3.0.0':
+    resolution: {integrity: sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -2628,6 +2637,9 @@ packages:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
+  anynum@1.0.1:
+    resolution: {integrity: sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==}
+
   arctic@3.7.0:
     resolution: {integrity: sha512-ZMQ+f6VazDgUJOd+qNV+H7GohNSYal1mVjm5kEaZfE2Ifb7Ss70w+Q7xpJC87qZDkMZIXYf0pTIYZA0OPasSbw==}
 
@@ -3255,6 +3267,13 @@ packages:
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
 
+  fast-xml-builder@1.3.0:
+    resolution: {integrity: sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==}
+
+  fast-xml-parser@5.10.1:
+    resolution: {integrity: sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw==}
+    hasBin: true
+
   fastest-levenshtein@1.0.16:
     resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
     engines: {node: '>= 4.9.1'}
@@ -3578,6 +3597,9 @@ packages:
 
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
+  is-unsafe@2.0.0:
+    resolution: {integrity: sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA==}
 
   isbot@5.2.1:
     resolution: {integrity: sha512-dJ+LpKyClQZ7NG+j3OensC/mAZkGpukE9YUrgPYvAZj2doVL0edfDgywTUh5CXa0o+nW9a1V9e5+CJTX8+SxRw==}
@@ -4073,6 +4095,10 @@ packages:
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
+
+  path-expression-matcher@1.6.2:
+    resolution: {integrity: sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==}
+    engines: {node: '>=14.0.0'}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -4589,6 +4615,9 @@ packages:
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
+
+  strnum@2.4.1:
+    resolution: {integrity: sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==}
 
   stylelint-config-recommended-scss@17.0.1:
     resolution: {integrity: sha512-x5DVehzJudcwF0od3sGpgkln2PLLranFE7twwbp7dqDINCyZvwzFkMc6TLhNOvazRiVBJYATQLouJY0xPGB8WA==}
@@ -5193,6 +5222,10 @@ packages:
       utf-8-validate:
         optional: true
 
+  xml-naming@0.3.0:
+    resolution: {integrity: sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==}
+    engines: {node: '>=16.0.0'}
+
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
@@ -5487,6 +5520,12 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  '@astrojs/rss@4.0.19':
+    dependencies:
+      fast-xml-parser: 5.10.1
+      piccolore: 0.1.3
+      zod: 4.4.3
 
   '@astrojs/telemetry@3.3.3':
     dependencies:
@@ -6780,6 +6819,8 @@ snapshots:
   '@neon-rs/load@0.0.4':
     optional: true
 
+  '@nodable/entities@3.0.0': {}
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -7758,6 +7799,8 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.2
 
+  anynum@1.0.1: {}
+
   arctic@3.7.0:
     dependencies:
       '@oslojs/crypto': 1.0.1
@@ -8559,6 +8602,20 @@ snapshots:
     dependencies:
       fast-string-width: 3.0.2
 
+  fast-xml-builder@1.3.0:
+    dependencies:
+      path-expression-matcher: 1.6.2
+      xml-naming: 0.3.0
+
+  fast-xml-parser@5.10.1:
+    dependencies:
+      '@nodable/entities': 3.0.0
+      fast-xml-builder: 1.3.0
+      is-unsafe: 2.0.0
+      path-expression-matcher: 1.6.2
+      strnum: 2.4.1
+      xml-naming: 0.3.0
+
   fastest-levenshtein@1.0.16: {}
 
   fastq@1.20.1:
@@ -8878,6 +8935,8 @@ snapshots:
   is-plain-object@5.0.0: {}
 
   is-promise@4.0.0: {}
+
+  is-unsafe@2.0.0: {}
 
   isbot@5.2.1: {}
 
@@ -9301,6 +9360,8 @@ snapshots:
   path-browserify@1.0.1: {}
 
   path-exists@4.0.0: {}
+
+  path-expression-matcher@1.6.2: {}
 
   path-key@3.1.1: {}
 
@@ -9994,6 +10055,10 @@ snapshots:
 
   strip-json-comments@2.0.1: {}
 
+  strnum@2.4.1:
+    dependencies:
+      anynum: 1.0.1
+
   stylelint-config-recommended-scss@17.0.1(postcss@8.5.20)(stylelint@17.14.1(supports-color@10.2.2)(typescript@6.0.3)):
     dependencies:
       postcss-scss: 4.0.9(postcss@8.5.20)
@@ -10538,6 +10603,8 @@ snapshots:
 
   ws@8.21.1:
     optional: true
+
+  xml-naming@0.3.0: {}
 
   xtend@4.0.2:
     optional: true

--- a/src/components/layout/PrimaryNav.astro
+++ b/src/components/layout/PrimaryNav.astro
@@ -20,15 +20,6 @@ function isCurrentUrl(url: string) {
 			Skip to primary content
 		</a>
 	</div>
-	<div class="skip-link">
-		<a
-			class="visually-hidden"
-			href="#secondary"
-			title="Skip to secondary content"
-		>
-			Skip to secondary content
-		</a>
-	</div>
 	<div class="navbar navbar-expand-lg navbar-dark bg-dark">
 		<button
 			class="navbar-toggler"

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -66,7 +66,7 @@ const page = createSitePageContext({
 	url: Astro.url,
 	siteTitle,
 	siteDescription,
-	siteUrl: settings?.url,
+	siteUrl: settings?.url || Astro.site?.origin,
 	title,
 	description,
 	content,

--- a/src/lib/site-config.ts
+++ b/src/lib/site-config.ts
@@ -1,6 +1,7 @@
 export const SITE_TITLE_FALLBACK = "Engaged Philosophy";
 export const SITE_TAGLINE_FALLBACK = "Civic Engagement in Philosophy Classes";
-export const WORDPRESS_SITE_URL = "https://www.engagedphilosophy.com";
+export const PUBLIC_SITE_URL = "https://www.engagedphilosophy.com";
+export const WORDPRESS_SITE_URL = PUBLIC_SITE_URL;
 export const PUBLIC_MEDIA_URL = "https://media.engagedphilosophy.com";
 export const CLOUDFLARE_ACCESS_TEAM_DOMAIN =
 	"engaged-philosophy.cloudflareaccess.com";

--- a/src/pages/feed/index.ts
+++ b/src/pages/feed/index.ts
@@ -1,0 +1,69 @@
+import rss from "@astrojs/rss";
+import type { APIRoute } from "astro";
+import { getSiteSettings } from "emdash";
+
+import { SITE_SETTINGS_CACHE_TAG } from "../../lib/cache-tags";
+import { getPublishedPosts } from "../../lib/content";
+import {
+	getEntryContent,
+	getEntryExcerpt,
+	getExcerptText,
+} from "../../lib/rich-text";
+import {
+	PUBLIC_EDGE_CACHE_MAX_AGE_SECONDS,
+	PUBLIC_EDGE_CACHE_SWR_SECONDS,
+	SITE_TAGLINE_FALLBACK,
+	SITE_TITLE_FALLBACK,
+} from "../../lib/site-config";
+
+function entryDate(entry: {
+	data: {
+		publishedAt?: Date | null;
+		createdAt?: Date | null;
+		updatedAt?: Date | null;
+	};
+}) {
+	return entry.data.publishedAt ?? entry.data.createdAt ?? entry.data.updatedAt;
+}
+
+export const prerender = false;
+
+export const GET: APIRoute = async ({ cache, site, url }) => {
+	cache.set({
+		maxAge: PUBLIC_EDGE_CACHE_MAX_AGE_SECONDS,
+		swr: PUBLIC_EDGE_CACHE_SWR_SECONDS,
+		tags: [SITE_SETTINGS_CACHE_TAG, "posts"],
+	});
+
+	const [settings, posts] = await Promise.all([
+		getSiteSettings(),
+		getPublishedPosts(),
+	]);
+	const response = await rss({
+		title: settings?.title || SITE_TITLE_FALLBACK,
+		description: settings?.tagline || SITE_TAGLINE_FALLBACK,
+		site: settings?.url || site || url.origin,
+		customData: "<language>en-US</language>",
+		items: [...posts]
+			.sort(
+				(left, right) =>
+					(entryDate(right)?.valueOf() ?? 0) -
+					(entryDate(left)?.valueOf() ?? 0),
+			)
+			.map((post) => ({
+				title: post.data.title,
+				link: `/${post.data.path}/`,
+				pubDate: entryDate(post) ?? undefined,
+				description:
+					getExcerptText(
+						getEntryExcerpt(post.data),
+						getEntryContent(post.data),
+					) || undefined,
+				categories: post.data.terms?.category?.map((term) => term.label),
+			})),
+	});
+
+	response.headers.set("Content-Type", "application/rss+xml; charset=utf-8");
+	response.headers.set("Cache-Control", "public, max-age=0, must-revalidate");
+	return response;
+};

--- a/src/pages/feed/index.ts
+++ b/src/pages/feed/index.ts
@@ -3,7 +3,7 @@ import type { APIRoute } from "astro";
 import { getSiteSettings } from "emdash";
 
 import { SITE_SETTINGS_CACHE_TAG } from "../../lib/cache-tags";
-import { getPublishedPosts } from "../../lib/content";
+import { getRecentPosts } from "../../lib/content";
 import {
 	getEntryContent,
 	getEntryExcerpt,
@@ -15,6 +15,9 @@ import {
 	SITE_TAGLINE_FALLBACK,
 	SITE_TITLE_FALLBACK,
 } from "../../lib/site-config";
+import { sitemapOrigin } from "../../lib/sitemap";
+
+const RSS_POST_LIMIT = 10;
 
 function entryDate(entry: {
 	data: {
@@ -35,32 +38,26 @@ export const GET: APIRoute = async ({ cache, site, url }) => {
 		tags: [SITE_SETTINGS_CACHE_TAG, "posts"],
 	});
 
-	const [settings, posts] = await Promise.all([
+	const [settings, { entries: posts }] = await Promise.all([
 		getSiteSettings(),
-		getPublishedPosts(),
+		getRecentPosts(RSS_POST_LIMIT),
 	]);
 	const response = await rss({
 		title: settings?.title || SITE_TITLE_FALLBACK,
 		description: settings?.tagline || SITE_TAGLINE_FALLBACK,
-		site: settings?.url || site || url.origin,
+		site: sitemapOrigin(settings?.url || site?.origin, url.origin),
 		customData: "<language>en-US</language>",
-		items: [...posts]
-			.sort(
-				(left, right) =>
-					(entryDate(right)?.valueOf() ?? 0) -
-					(entryDate(left)?.valueOf() ?? 0),
-			)
-			.map((post) => ({
-				title: post.data.title,
-				link: `/${post.data.path}/`,
-				pubDate: entryDate(post) ?? undefined,
-				description:
-					getExcerptText(
-						getEntryExcerpt(post.data),
-						getEntryContent(post.data),
-					) || undefined,
-				categories: post.data.terms?.category?.map((term) => term.label),
-			})),
+		items: posts.map((post) => ({
+			title: post.data.title,
+			link: `/${post.data.path}/`,
+			pubDate: entryDate(post) ?? undefined,
+			description:
+				getExcerptText(
+					getEntryExcerpt(post.data),
+					getEntryContent(post.data),
+				) || undefined,
+			categories: post.data.terms?.category?.map((term) => term.label),
+		})),
 	});
 
 	response.headers.set("Content-Type", "application/rss+xml; charset=utf-8");

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -41,7 +41,7 @@ function toSitemapEntry(
 
 export const prerender = false;
 
-export const GET: APIRoute = async ({ cache, url }) => {
+export const GET: APIRoute = async ({ cache, site, url }) => {
 	cache.set({
 		maxAge: PUBLIC_EDGE_CACHE_MAX_AGE_SECONDS,
 		swr: PUBLIC_EDGE_CACHE_SWR_SECONDS,
@@ -53,7 +53,7 @@ export const GET: APIRoute = async ({ cache, url }) => {
 		getPublishedPosts(),
 		getPublishedProjects(),
 	]);
-	const origin = sitemapOrigin(settings?.url, url.origin);
+	const origin = sitemapOrigin(settings?.url || site?.origin, url.origin);
 	const body = renderSitemapXml(origin, [
 		...pages.map((entry) => toSitemapEntry(entry, origin)),
 		...posts.map((entry) => toSitemapEntry(entry, origin)),


### PR DESCRIPTION
## Summary

- remove the global secondary-content skip link because most pages do not render that target
- set the canonical production site URL so sitemap and metadata URLs use HTTPS
- restore the legacy `/feed/` URL with an EmDash-backed RSS feed and existing edge-cache policy
- keep RSS generation within the old WordPress 10-item behavior and normalize its canonical origin

The live content cleanup was applied separately through revision-preserving D1 migrations: three malformed internal links were removed or corrected, 42 dead external links were replaced with dated Wayback snapshots, and four were updated to working live URLs. Those generated migrations and database snapshots are intentionally excluded from this PR.

## Testing

- `mise exec -- pnpm run ci`
- Lychee 0.24.2 against all 244 production sitemap pages, including fragments and embedded assets
- focused Lychee validation of the corrected Wayback links after repairing the replacement-order issue
- production D1 consistency check: zero nested Wayback URLs and zero live-revision/content mismatches

## Notes

The WordPress archive confirmed that `/feed/` was previously a real RSS endpoint containing 10 items. It also showed that the global `#secondary` link was already broken on pages without a sidebar, so this removes that inherited defect rather than changing intended behavior.