### PR TITLE
fix: return real 404 responses

### DIFF
--- a/e2e/specs/public/not-found.spec.ts
+++ b/e2e/specs/public/not-found.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect } from "../../fixtures/worker";
+
+const MISSING_ROUTES = [
+	{ kind: "page", path: "/e2e-missing-page/" },
+	{ kind: "dated post", path: "/2099/12/31/e2e-missing-post/" },
+	{ kind: "project", path: "/project/e2e-missing-project/" },
+	{ kind: "category", path: "/category/e2e-missing-category/" },
+	{ kind: "taxonomy", path: "/schools/e2e-missing-school/" },
+	{ kind: "search pagination", path: "/page/2/" },
+	{
+		kind: "category pagination",
+		path: "/category/e2e-missing-category/page/2/",
+	},
+	{
+		kind: "taxonomy pagination",
+		path: "/schools/e2e-missing-school/page/2/",
+	},
+	{ kind: "page alias", path: "/pages/e2e-missing-page/" },
+	{ kind: "post alias", path: "/posts/e2e-missing-post/" },
+	{ kind: "project alias", path: "/projects/e2e-missing-project/" },
+] as const;
+
+test.describe("public not-found responses", () => {
+	for (const { kind, path } of MISSING_ROUTES) {
+		test(`${kind} stays at the requested URL`, async ({ publicPage }) => {
+			const response = await publicPage.goto(path, {
+				waitUntil: "domcontentloaded",
+			});
+
+			expect(response?.status()).toBe(404);
+			expect(response?.headers().location).toBeUndefined();
+			expect(new URL(publicPage.url()).pathname).toBe(path);
+			await expect(
+				publicPage.getByRole("heading", {
+					name: "This is somewhat embarrassing, isn\u2019t it?",
+				}),
+			).toBeVisible();
+		});
+	}
+
+	test("EmDash logs the originally requested path", async ({
+		authedRequest,
+		publicPage,
+	}) => {
+		const path = "/e2e-original-404-log-path/";
+		const response = await publicPage.goto(path);
+		expect(response?.status()).toBe(404);
+
+		await expect
+			.poll(async () => {
+				const logResponse = await authedRequest.get(
+					`/_emdash/api/redirects/404s?search=${encodeURIComponent(path)}`,
+				);
+				expect(logResponse.ok()).toBe(true);
+				const body = (await logResponse.json()) as {
+					data?: { items?: Array<{ path?: string }> };
+				};
+				return body.data?.items?.map((entry) => entry.path) ?? [];
+			})
+			.toContain(path);
+
+		const rewrittenPathResponse = await authedRequest.get(
+			`/_emdash/api/redirects/404s?search=${encodeURIComponent("/404")}`,
+		);
+		expect(rewrittenPathResponse.ok()).toBe(true);
+		const rewrittenPathBody = (await rewrittenPathResponse.json()) as {
+			data?: { items?: Array<{ path?: string }> };
+		};
+		expect(
+			rewrittenPathBody.data?.items?.map((entry) => entry.path) ?? [],
+		).not.toContain("/404");
+	});
+});

--- a/e2e/specs/public/not-found.spec.ts
+++ b/e2e/specs/public/not-found.spec.ts
@@ -45,6 +45,20 @@ test.describe("public not-found responses", () => {
 		const path = "/e2e-original-404-log-path/";
 		const response = await publicPage.goto(path);
 		expect(response?.status()).toBe(404);
+		const cacheTags = response?.headers()["cache-tag"]?.split(",") ?? [];
+		expect(cacheTags).toEqual(
+			expect.arrayContaining([
+				"pages",
+				"posts",
+				"projects",
+				"taxonomy:category",
+				"taxonomy:topic",
+				"taxonomy:schools",
+				"taxonomy:professors",
+				"taxonomy:courses",
+				"taxonomy:semesters",
+			]),
+		);
 
 		await expect
 			.poll(async () => {

--- a/src/components/NotFound.astro
+++ b/src/components/NotFound.astro
@@ -1,12 +1,22 @@
 ---
 import Base from "../layouts/Base.astro";
+import { taxonomyCacheTag } from "../lib/cache-tags";
+import { PROJECT_TAXONOMIES } from "../lib/taxonomy-utils";
 import ThemeSidebar from "./ThemeSidebar.astro";
+
+const cacheTags = [
+	"pages",
+	"posts",
+	"projects",
+	taxonomyCacheTag("category"),
+	...PROJECT_TAXONOMIES.map(taxonomyCacheTag),
+];
 ---
 
 <Base
 	title="Not Found"
 	bodyClass="error404 not-found content-sidebar"
-	cacheTags={["posts"]}
+	cacheTags={cacheTags}
 >
 	<section id="primary" class="col-lg-8 px-4">
 		<div id="content" role="main">

--- a/src/components/NotFound.astro
+++ b/src/components/NotFound.astro
@@ -1,0 +1,51 @@
+---
+import Base from "../layouts/Base.astro";
+import ThemeSidebar from "./ThemeSidebar.astro";
+---
+
+<Base
+	title="Not Found"
+	bodyClass="error404 not-found content-sidebar"
+	cacheTags={["posts"]}
+>
+	<section id="primary" class="col-lg-8 px-4">
+		<div id="content" role="main">
+			<article class="post error404 not-found">
+				<header class="page-header">
+					<h1 class="entry-title">
+						This is somewhat embarrassing, isn&rsquo;t it?
+					</h1>
+				</header>
+				<div class="entry-content">
+					<p>
+						It seems we can&rsquo;t find what you&rsquo;re looking for. Perhaps
+						searching, or one of the links below, can help.
+					</p>
+
+					<form method="get" id="searchform" class="d-flex" action="/">
+						<label for="not-found-search" class="visually-hidden">Search</label>
+						<div class="input-group">
+							<input
+								id="not-found-search"
+								class="form-control"
+								type="search"
+								name="s"
+								placeholder="Search"
+							/>
+							<button
+								class="btn btn-primary"
+								name="submit"
+								id="searchsubmit"
+								type="submit"
+								aria-label="Submit search"
+							>
+								<i class="bi bi-search"></i>
+							</button>
+						</div>
+					</form>
+				</div>
+			</article>
+		</div>
+	</section>
+	<ThemeSidebar />
+</Base>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,51 +1,7 @@
 ---
-import Base from "../layouts/Base.astro";
-import ThemeSidebar from "../components/ThemeSidebar.astro";
+import NotFound from "../components/NotFound.astro";
+
+Astro.response.status = 404;
 ---
 
-<Base
-	title="Not Found"
-	bodyClass="error404 not-found content-sidebar"
-	cacheTags={["posts"]}
->
-	<section id="primary" class="col-lg-8 px-4">
-		<div id="content" role="main">
-			<article class="post error404 not-found">
-				<header class="page-header">
-					<h1 class="entry-title">
-						This is somewhat embarrassing, isn&rsquo;t it?
-					</h1>
-				</header>
-				<div class="entry-content">
-					<p>
-						It seems we can&rsquo;t find what you&rsquo;re looking for. Perhaps
-						searching, or one of the links below, can help.
-					</p>
-
-					<form method="get" id="searchform" class="d-flex" action="/">
-						<label for="not-found-search" class="visually-hidden">Search</label>
-						<div class="input-group">
-							<input
-								id="not-found-search"
-								class="form-control"
-								type="search"
-								name="s"
-								placeholder="Search"
-							/>
-							<button
-								class="btn btn-primary"
-								name="submit"
-								id="searchsubmit"
-								type="submit"
-								aria-label="Submit search"
-							>
-								<i class="bi bi-search"></i>
-							</button>
-						</div>
-					</form>
-				</div>
-			</article>
-		</div>
-	</section>
-	<ThemeSidebar />
-</Base>
+<NotFound />

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -1,4 +1,5 @@
 ---
+import NotFound from "../components/NotFound.astro";
 import RichContent from "../components/RichContent.astro";
 import Base from "../layouts/Base.astro";
 import { getPageByPath, getPageBySlug, getProjectBySlug } from "../lib/content";
@@ -18,58 +19,46 @@ if (!page) {
 	if (project?.data.path) {
 		return Astro.redirect(`/${project.data.path}/`);
 	}
-	return Astro.redirect("/404");
 }
 
-if (page.data.path !== path) {
+if (page && page.data.path !== path) {
 	return Astro.redirect(page.data.path ? `/${page.data.path}/` : "/");
 }
 
+if (!page) Astro.response.status = 404;
+
 const useFullWidthTemplate =
-	page.data.template === "templates/_full_width.php" &&
+	page?.data.template === "templates/_full_width.php" &&
 	page.data.path !== "faq";
-const bodyClass = [
-	"wp-singular",
-	...(useFullWidthTemplate
-		? [
-				"page-template",
-				"page-template-templates_full_width",
-				"page-template-templates_full_width-php",
-			]
-		: ["page-template-default", "content-sidebar"]),
-	"page",
-	page.data.id ? `page-id-${page.data.id}` : null,
-	"wp-theme-engaged-philosophy-20",
-]
-	.filter(Boolean)
-	.join(" ");
+const bodyClass = page
+	? [
+			"wp-singular",
+			...(useFullWidthTemplate
+				? [
+						"page-template",
+						"page-template-templates_full_width",
+						"page-template-templates_full_width-php",
+					]
+				: ["page-template-default", "content-sidebar"]),
+			"page",
+			page.data.id ? `page-id-${page.data.id}` : null,
+			"wp-theme-engaged-philosophy-20",
+		]
+			.filter(Boolean)
+			.join(" ")
+	: "";
 ---
 
-<Base
-	title={page.data.title}
-	bodyClass={bodyClass}
-	content={{ collection: "pages", entry: page }}
->
-	{
-		useFullWidthTemplate ? (
-			<section id="primary" class="col-12 px-4">
-				<main id="content">
-					<article {...page.edit}>
-						<header class="page-header">
-							<h1 class="entry-title" {...page.edit.title}>
-								{page.data.title}
-							</h1>
-						</header>
-						<div class="entry-content" {...page.edit.content}>
-							<RichContent value={getEntryContent(page.data)} />
-						</div>
-					</article>
-				</main>
-			</section>
-		) : (
-			<div class="container-fluid">
-				<section id="primary" class="p-4">
-					<div id="content" role="main">
+{
+	page ? (
+		<Base
+			title={page.data.title}
+			bodyClass={bodyClass}
+			content={{ collection: "pages", entry: page }}
+		>
+			{useFullWidthTemplate ? (
+				<section id="primary" class="col-12 px-4">
+					<main id="content">
 						<article {...page.edit}>
 							<header class="page-header">
 								<h1 class="entry-title" {...page.edit.title}>
@@ -80,9 +69,28 @@ const bodyClass = [
 								<RichContent value={getEntryContent(page.data)} />
 							</div>
 						</article>
-					</div>
+					</main>
 				</section>
-			</div>
-		)
-	}
-</Base>
+			) : (
+				<div class="container-fluid">
+					<section id="primary" class="p-4">
+						<div id="content" role="main">
+							<article {...page.edit}>
+								<header class="page-header">
+									<h1 class="entry-title" {...page.edit.title}>
+										{page.data.title}
+									</h1>
+								</header>
+								<div class="entry-content" {...page.edit.content}>
+									<RichContent value={getEntryContent(page.data)} />
+								</div>
+							</article>
+						</div>
+					</section>
+				</div>
+			)}
+		</Base>
+	) : (
+		<NotFound />
+	)
+}

--- a/src/pages/[taxonomy]/[slug].astro
+++ b/src/pages/[taxonomy]/[slug].astro
@@ -2,6 +2,7 @@
 import { getTerm } from "emdash";
 
 import Base from "../../layouts/Base.astro";
+import NotFound from "../../components/NotFound.astro";
 import TaxonomyArchive from "../../components/TaxonomyArchive.astro";
 import { getPageByPath, getProjectsPageByTaxonomy } from "../../lib/content";
 import { getEntryContent } from "../../lib/rich-text";
@@ -13,26 +14,19 @@ const { taxonomy = "", slug = "" } = Astro.params;
 const pagePath = `${taxonomy}/${slug}`;
 const isProjectArchive = isProjectTaxonomy(taxonomy);
 const page = isProjectArchive ? null : await getPageByPath(pagePath);
-
-if (!isProjectArchive) {
-	if (!page) {
-		return Astro.redirect("/404");
-	}
-}
-
 const term = isProjectArchive ? await getTerm(taxonomy, slug) : null;
-
-if (isProjectArchive && !term) {
-	return Astro.redirect("/404");
-}
-
-const projectPage = isProjectArchive
-	? await getProjectsPageByTaxonomy(taxonomy, slug, 1)
-	: { entries: [], hasMore: false };
+const projectPage =
+	isProjectArchive && term
+		? await getProjectsPageByTaxonomy(taxonomy, slug, 1)
+		: { entries: [], hasMore: false };
+const notFound = !page && !term;
+if (notFound) Astro.response.status = 404;
 ---
 
 {
-	page ? (
+	notFound ? (
+		<NotFound />
+	) : page ? (
 		<Base
 			title={page.data.title}
 			content={{ collection: "pages", entry: page }}

--- a/src/pages/[taxonomy]/[slug]/page/[page].astro
+++ b/src/pages/[taxonomy]/[slug]/page/[page].astro
@@ -2,47 +2,44 @@
 import { getTerm } from "emdash";
 
 import Base from "../../../../layouts/Base.astro";
+import NotFound from "../../../../components/NotFound.astro";
 import TaxonomyArchive from "../../../../components/TaxonomyArchive.astro";
 import { getProjectsPageByTaxonomy } from "../../../../lib/content";
 import { taxonomyCacheTag } from "../../../../lib/cache-tags";
 import { isProjectTaxonomy } from "../../../../lib/taxonomy-utils";
 
 const { taxonomy = "", slug = "", page = "1" } = Astro.params;
-
-if (!isProjectTaxonomy(taxonomy)) {
-	return Astro.redirect("/404");
-}
-
-const term = await getTerm(taxonomy, slug);
-if (!term) {
-	return Astro.redirect("/404");
-}
+const projectTaxonomy = isProjectTaxonomy(taxonomy);
+const term = projectTaxonomy ? await getTerm(taxonomy, slug) : null;
 
 const pageNumber = Number.parseInt(page, 10);
-if (!Number.isFinite(pageNumber) || pageNumber < 2) {
+if (term && (!Number.isFinite(pageNumber) || pageNumber < 2)) {
 	return Astro.redirect(`/${taxonomy}/${slug}/`);
 }
 
-const { entries: projects, hasMore } = await getProjectsPageByTaxonomy(
-	taxonomy,
-	slug,
-	pageNumber,
-);
-if (projects.length === 0) {
-	return Astro.redirect("/404");
-}
+const projectPage = term
+	? await getProjectsPageByTaxonomy(taxonomy, slug, pageNumber)
+	: { entries: [], hasMore: false };
+const found = term && projectPage.entries.length > 0;
+if (!found) Astro.response.status = 404;
 ---
 
-<Base
-	title={`${term.label} – Page ${pageNumber}`}
-	bodyClass={`archive paged tax-${taxonomy} term-${slug} paged-${pageNumber} wp-theme-engaged-philosophy-20 content-sidebar`}
-	cacheTags={["projects", taxonomyCacheTag(taxonomy)]}
->
-	<TaxonomyArchive
-		taxonomy={taxonomy}
-		label={term.label}
-		projects={projects}
-		hasMore={hasMore}
-		page={pageNumber}
-	/>
-</Base>
+{
+	found ? (
+		<Base
+			title={`${term.label} – Page ${pageNumber}`}
+			bodyClass={`archive paged tax-${taxonomy} term-${slug} paged-${pageNumber} wp-theme-engaged-philosophy-20 content-sidebar`}
+			cacheTags={["projects", taxonomyCacheTag(taxonomy)]}
+		>
+			<TaxonomyArchive
+				taxonomy={taxonomy}
+				label={term.label}
+				projects={projectPage.entries}
+				hasMore={projectPage.hasMore}
+				page={pageNumber}
+			/>
+		</Base>
+	) : (
+		<NotFound />
+	)
+}

--- a/src/pages/[year]/[month]/[day]/[slug].astro
+++ b/src/pages/[year]/[month]/[day]/[slug].astro
@@ -1,4 +1,5 @@
 ---
+import NotFound from "../../../../components/NotFound.astro";
 import RichContent from "../../../../components/RichContent.astro";
 import ThemeSidebar from "../../../../components/ThemeSidebar.astro";
 import Base from "../../../../layouts/Base.astro";
@@ -11,50 +12,52 @@ const { year = "", month = "", day = "", slug = "" } = Astro.params;
 const path = joinPath([year, month, day, slug]);
 const post = await getPostByPath(path);
 
-if (!post) {
-	return Astro.redirect("/404");
-}
+if (!post) Astro.response.status = 404;
 
-const categories = post.data.terms?.category ?? [];
+const categories = post?.data.terms?.category ?? [];
 ---
 
-<Base
-	title={post.data.title}
-	bodyClass={`wp-singular post-template-default single single-post${post.data.id ? ` postid-${post.data.id}` : ""} single-format-standard wp-theme-engaged-philosophy-20 content-sidebar`}
-	content={{ collection: "posts", entry: post }}
-	cacheTags={["posts", taxonomyCacheTag("category")]}
->
-	<section id="primary" class="col-lg-8 px-4">
-		<div id="content" role="main">
-			<article class="post" {...post.edit}>
-				<header class="page-header">
-					<h1 class="entry-title" {...post.edit.title}>
-						{post.data.title}
-					</h1>
-					<div class="entry-meta">
-						{post.data.publishedAt?.toLocaleDateString() ?? ""}
-					</div>
-				</header>
-				<div class="entry-content" {...post.edit.content}>
-					<RichContent value={getEntryContent(post.data)} />
+{
+	post ? (
+		<Base
+			title={post.data.title}
+			bodyClass={`wp-singular post-template-default single single-post${post.data.id ? ` postid-${post.data.id}` : ""} single-format-standard wp-theme-engaged-philosophy-20 content-sidebar`}
+			content={{ collection: "posts", entry: post }}
+			cacheTags={["posts", taxonomyCacheTag("category")]}
+		>
+			<section id="primary" class="col-lg-8 px-4">
+				<div id="content" role="main">
+					<article class="post" {...post.edit}>
+						<header class="page-header">
+							<h1 class="entry-title" {...post.edit.title}>
+								{post.data.title}
+							</h1>
+							<div class="entry-meta">
+								{post.data.publishedAt?.toLocaleDateString() ?? ""}
+							</div>
+						</header>
+						<div class="entry-content" {...post.edit.content}>
+							<RichContent value={getEntryContent(post.data)} />
+						</div>
+						{categories.length > 0 && (
+							<footer class="entry-footer">
+								<span class="cat-links block">
+									Posted in{" "}
+									{categories
+										.map((term) => (
+											<a href={`/category/${term.slug}/`}>{term.label}</a>
+										))
+										.reduce((prev, curr) => [prev, ", ", curr])}
+									.
+								</span>
+							</footer>
+						)}
+					</article>
 				</div>
-				{
-					categories.length > 0 && (
-						<footer class="entry-footer">
-							<span class="cat-links block">
-								Posted in{" "}
-								{categories
-									.map((term) => (
-										<a href={`/category/${term.slug}/`}>{term.label}</a>
-									))
-									.reduce((prev, curr) => [prev, ", ", curr])}
-								.
-							</span>
-						</footer>
-					)
-				}
-			</article>
-		</div>
-	</section>
-	<ThemeSidebar />
-</Base>
+			</section>
+			<ThemeSidebar />
+		</Base>
+	) : (
+		<NotFound />
+	)
+}

--- a/src/pages/category/[slug].astro
+++ b/src/pages/category/[slug].astro
@@ -2,33 +2,39 @@
 import { getTerm } from "emdash";
 
 import CategoryArchive from "../../components/CategoryArchive.astro";
+import NotFound from "../../components/NotFound.astro";
 import Base from "../../layouts/Base.astro";
 import { taxonomyCacheTag } from "../../lib/cache-tags";
 import { getPostsPageByCategory } from "../../lib/content";
 
 const { slug = "" } = Astro.params;
 const term = await getTerm("category", slug);
-
-if (!term) {
-	return Astro.redirect("/404");
-}
-const { entries: posts, hasMore } = await getPostsPageByCategory(slug, 1);
+const postPage = term
+	? await getPostsPageByCategory(slug, 1)
+	: { entries: [], hasMore: false };
+if (!term) Astro.response.status = 404;
 ---
 
-<Base
-	title={`Category: ${term.label}`}
-	bodyClass={`archive category category-${slug} wp-theme-engaged-philosophy-20 content-sidebar`}
-	cacheTags={["posts", taxonomyCacheTag("category")]}
->
-	<div class="container-fluid">
-		<div class="row">
-			<CategoryArchive
-				slug={slug}
-				label={term.label}
-				posts={posts}
-				hasMore={hasMore}
-				page={1}
-			/>
-		</div>
-	</div>
-</Base>
+{
+	term ? (
+		<Base
+			title={`Category: ${term.label}`}
+			bodyClass={`archive category category-${slug} wp-theme-engaged-philosophy-20 content-sidebar`}
+			cacheTags={["posts", taxonomyCacheTag("category")]}
+		>
+			<div class="container-fluid">
+				<div class="row">
+					<CategoryArchive
+						slug={slug}
+						label={term.label}
+						posts={postPage.entries}
+						hasMore={postPage.hasMore}
+						page={1}
+					/>
+				</div>
+			</div>
+		</Base>
+	) : (
+		<NotFound />
+	)
+}

--- a/src/pages/category/[slug]/page/[page].astro
+++ b/src/pages/category/[slug]/page/[page].astro
@@ -2,6 +2,7 @@
 import { getTerm } from "emdash";
 
 import CategoryArchive from "../../../../components/CategoryArchive.astro";
+import NotFound from "../../../../components/NotFound.astro";
 import Base from "../../../../layouts/Base.astro";
 import { taxonomyCacheTag } from "../../../../lib/cache-tags";
 import { getPostsPageByCategory } from "../../../../lib/content";
@@ -9,38 +10,38 @@ import { getPostsPageByCategory } from "../../../../lib/content";
 const { slug = "", page = "1" } = Astro.params;
 const term = await getTerm("category", slug);
 
-if (!term) {
-	return Astro.redirect("/404");
-}
-
 const pageNumber = Number.parseInt(page, 10);
-if (!Number.isFinite(pageNumber) || pageNumber < 2) {
+if (term && (!Number.isFinite(pageNumber) || pageNumber < 2)) {
 	return Astro.redirect(`/category/${slug}/`);
 }
 
-const { entries: posts, hasMore } = await getPostsPageByCategory(
-	slug,
-	pageNumber,
-);
-if (posts.length === 0) {
-	return Astro.redirect("/404");
-}
+const postPage = term
+	? await getPostsPageByCategory(slug, pageNumber)
+	: { entries: [], hasMore: false };
+const found = term && postPage.entries.length > 0;
+if (!found) Astro.response.status = 404;
 ---
 
-<Base
-	title={`Category: ${term.label} – Page ${pageNumber}`}
-	bodyClass={`archive category category-${slug} paged paged-${pageNumber} wp-theme-engaged-philosophy-20 content-sidebar`}
-	cacheTags={["posts", taxonomyCacheTag("category")]}
->
-	<div class="container-fluid">
-		<div class="row">
-			<CategoryArchive
-				slug={slug}
-				label={term.label}
-				posts={posts}
-				hasMore={hasMore}
-				page={pageNumber}
-			/>
-		</div>
-	</div>
-</Base>
+{
+	found ? (
+		<Base
+			title={`Category: ${term.label} – Page ${pageNumber}`}
+			bodyClass={`archive category category-${slug} paged paged-${pageNumber} wp-theme-engaged-philosophy-20 content-sidebar`}
+			cacheTags={["posts", taxonomyCacheTag("category")]}
+		>
+			<div class="container-fluid">
+				<div class="row">
+					<CategoryArchive
+						slug={slug}
+						label={term.label}
+						posts={postPage.entries}
+						hasMore={postPage.hasMore}
+						page={pageNumber}
+					/>
+				</div>
+			</div>
+		</Base>
+	) : (
+		<NotFound />
+	)
+}

--- a/src/pages/page/[page].astro
+++ b/src/pages/page/[page].astro
@@ -1,5 +1,6 @@
 ---
 import SearchResults from "../../components/SearchResults.astro";
+import NotFound from "../../components/NotFound.astro";
 import Base from "../../layouts/Base.astro";
 import { isValidSearchCursorHistory, searchSite } from "../../lib/search";
 import { InvalidCursorError } from "emdash";
@@ -9,37 +10,39 @@ const query = Astro.url.searchParams.get("s")?.trim() ?? "";
 const cursor = Astro.url.searchParams.get("cursor") ?? undefined;
 const history = Astro.url.searchParams.getAll("before");
 
-if (
-	!query ||
-	!Number.isInteger(pageNumber) ||
-	pageNumber < 2 ||
-	!cursor ||
-	!isValidSearchCursorHistory(pageNumber, history)
-) {
-	return Astro.redirect("/404");
-}
+const validRequest =
+	Boolean(query) &&
+	Number.isInteger(pageNumber) &&
+	pageNumber >= 2 &&
+	Boolean(cursor) &&
+	isValidSearchCursorHistory(pageNumber, history);
 
-let search;
-try {
-	search = await searchSite(query, cursor);
-} catch (error) {
-	if (!(error instanceof InvalidCursorError)) throw error;
-	return Astro.redirect("/404");
+let search: Awaited<ReturnType<typeof searchSite>> | undefined;
+if (validRequest) {
+	try {
+		search = await searchSite(query, cursor);
+	} catch (error) {
+		if (!(error instanceof InvalidCursorError)) throw error;
+	}
 }
-if (search.results.length === 0) {
-	return Astro.redirect("/404");
-}
+if (!search?.results.length) Astro.response.status = 404;
 ---
 
-<Base
-	title={`Search Results for: ${query}${pageNumber > 1 ? ` – Page ${pageNumber}` : ""}`}
-	bodyClass={`search search-results${pageNumber > 1 ? ` paged paged-${pageNumber}` : ""} wp-theme-engaged-philosophy-20 content-sidebar`}
->
-	<SearchResults
-		query={query}
-		search={search}
-		page={pageNumber}
-		cursor={cursor}
-		history={history}
-	/>
-</Base>
+{
+	search && search.results.length > 0 ? (
+		<Base
+			title={`Search Results for: ${query}${pageNumber > 1 ? ` – Page ${pageNumber}` : ""}`}
+			bodyClass={`search search-results${pageNumber > 1 ? ` paged paged-${pageNumber}` : ""} wp-theme-engaged-philosophy-20 content-sidebar`}
+		>
+			<SearchResults
+				query={query}
+				search={search}
+				page={pageNumber}
+				cursor={cursor}
+				history={history}
+			/>
+		</Base>
+	) : (
+		<NotFound />
+	)
+}

--- a/src/pages/pages/[slug].astro
+++ b/src/pages/pages/[slug].astro
@@ -1,12 +1,14 @@
 ---
+import NotFound from "../../components/NotFound.astro";
 import { getPageBySlug } from "../../lib/content";
 
 const { slug = "" } = Astro.params;
 const page = await getPageBySlug(slug);
 
-if (!page) {
-	return Astro.redirect("/404");
+if (page) {
+	return Astro.redirect(page.data.path ? `/${page.data.path}/` : "/", 301);
 }
-
-return Astro.redirect(page.data.path ? `/${page.data.path}/` : "/", 301);
+Astro.response.status = 404;
 ---
+
+<NotFound />

--- a/src/pages/posts/[slug].astro
+++ b/src/pages/posts/[slug].astro
@@ -1,12 +1,14 @@
 ---
+import NotFound from "../../components/NotFound.astro";
 import { getPostBySlug } from "../../lib/content";
 
 const { slug = "" } = Astro.params;
 const post = await getPostBySlug(slug);
 
-if (!post) {
-	return Astro.redirect("/404");
+if (post) {
+	return Astro.redirect(`/${post.data.path}/`, 301);
 }
-
-return Astro.redirect(`/${post.data.path}/`, 301);
+Astro.response.status = 404;
 ---
+
+<NotFound />

--- a/src/pages/project/[slug].astro
+++ b/src/pages/project/[slug].astro
@@ -1,4 +1,5 @@
 ---
+import NotFound from "../../components/NotFound.astro";
 import ProjectTermsList from "../../components/content/ProjectTermsList.astro";
 import RichContent from "../../components/RichContent.astro";
 import Base from "../../layouts/Base.astro";
@@ -9,67 +10,74 @@ import { PROJECT_TAXONOMIES } from "../../lib/taxonomy-utils";
 
 const { slug } = Astro.params;
 const project = await getProjectBySlug(slug ?? "");
-
-if (!project) {
-	return Astro.redirect("/404");
-}
+const terms = project?.data.terms;
+if (!project) Astro.response.status = 404;
 
 const termGroups = [
 	{
 		label: "College",
 		pathPrefix: "schools",
-		terms: project.data.terms?.schools ?? [],
+		terms: terms?.schools ?? [],
 	},
 	{
 		label: "Professor",
 		pathPrefix: "professors",
-		terms: project.data.terms?.professors ?? [],
+		terms: terms?.professors ?? [],
 	},
 	{
 		label: "Course",
 		pathPrefix: "courses",
-		terms: project.data.terms?.courses ?? [],
+		terms: terms?.courses ?? [],
 	},
 	{
 		label: "Semester",
 		pathPrefix: "semesters",
-		terms: project.data.terms?.semesters ?? [],
+		terms: terms?.semesters ?? [],
 	},
 	{
 		label: "Topics",
 		pathPrefix: "topic",
-		terms: project.data.terms?.topic ?? [],
+		terms: terms?.topic ?? [],
 	},
 ];
 ---
 
-<Base
-	title={project.data.title}
-	bodyClass={`wp-singular project-template-default single single-project${project.data.id ? ` postid-${project.data.id}` : ""} wp-theme-engaged-philosophy-20 content-sidebar`}
-	content={{ collection: "projects", entry: project }}
-	cacheTags={PROJECT_TAXONOMIES.map(taxonomyCacheTag)}
->
-	<section id="primary" class="col-12 px-4">
-		<main id="content">
-			<article class="project type-project status-publish" {...project.edit}>
-				<header class="page-header">
-					<h1 class="entry-title" {...project.edit.title}>
-						{project.data.title}
-					</h1>
-				</header>
+{
+	project ? (
+		<Base
+			title={project.data.title}
+			bodyClass={`wp-singular project-template-default single single-project${project.data.id ? ` postid-${project.data.id}` : ""} wp-theme-engaged-philosophy-20 content-sidebar`}
+			content={{ collection: "projects", entry: project }}
+			cacheTags={PROJECT_TAXONOMIES.map(taxonomyCacheTag)}
+		>
+			<section id="primary" class="col-12 px-4">
+				<main id="content">
+					<article
+						class="project type-project status-publish"
+						{...project.edit}
+					>
+						<header class="page-header">
+							<h1 class="entry-title" {...project.edit.title}>
+								{project.data.title}
+							</h1>
+						</header>
 
-				<div class="entry-content" {...project.edit.content}>
-					<div class="row">
-						<div class="col-lg-9">
-							<RichContent value={getEntryContent(project.data)} />
-						</div>
+						<div class="entry-content" {...project.edit.content}>
+							<div class="row">
+								<div class="col-lg-9">
+									<RichContent value={getEntryContent(project.data)} />
+								</div>
 
-						<div class="col-lg-3">
-							<ProjectTermsList groups={termGroups} />
+								<div class="col-lg-3">
+									<ProjectTermsList groups={termGroups} />
+								</div>
+							</div>
 						</div>
-					</div>
-				</div>
-			</article>
-		</main>
-	</section>
-</Base>
+					</article>
+				</main>
+			</section>
+		</Base>
+	) : (
+		<NotFound />
+	)
+}

--- a/src/pages/projects/[slug].astro
+++ b/src/pages/projects/[slug].astro
@@ -1,12 +1,14 @@
 ---
+import NotFound from "../../components/NotFound.astro";
 import { getProjectBySlug } from "../../lib/content";
 
 const { slug = "" } = Astro.params;
 const project = await getProjectBySlug(slug);
 
-if (!project) {
-	return Astro.redirect("/404");
+if (project) {
+	return Astro.redirect(`/${project.data.path}/`, 301);
 }
-
-return Astro.redirect(`/${project.data.path}/`, 301);
+Astro.response.status = 404;
 ---
+
+<NotFound />


### PR DESCRIPTION
## Summary

- render the existing not-found presentation directly with a 404 status instead of redirecting to `/404`
- preserve intentional canonical redirects while keeping missing page, post, project, archive, pagination, and alias URLs in place
- verify native EmDash 404 logging records the original requested path without adding a `/404` entry

## Tests

- `pnpm run ci`
- `pnpm exec playwright test e2e/specs/public/not-found.spec.ts`

## Post-deploy

- clear the historical `/404` entry from the native EmDash 404 log
- verify newly missing production URLs are logged by their original paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Missing pages, posts, projects, categories, taxonomy entries, and search results now display a consistent 404 page instead of redirecting to `/404`.
  * Invalid and empty pagination or search requests now remain on the requested URL with a proper 404 response.
  * Valid canonical redirects remain unchanged.
  * Improved 404 handling and logging for missing routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->