### PR TITLE
docs: document media usage repair

### DIFF
--- a/docs/launch-checklist.md
+++ b/docs/launch-checklist.md
@@ -15,6 +15,35 @@ do not reimport from WordPress.
 
 Use `LIVE_SMOKE_PATH_FILE` with `pnpm run smoke:live` for one-off path lists.
 
+## Post-Migration Maintenance
+
+After a direct content migration or bulk content rewrite that bypasses the
+EmDash content API, authenticate through Cloudflare Access and rebuild
+EmDash's media usage index:
+
+```sh
+cloudflared access login https://www.engagedphilosophy.com/_emdash/
+emdash_access_jwt="$(
+  cloudflared access token \
+    --app https://www.engagedphilosophy.com/_emdash/
+)"
+pnpm exec emdash media repair-usage --all \
+  --url https://www.engagedphilosophy.com \
+  --header "Cf-Access-Token: ${emdash_access_jwt}" \
+  --json
+unset emdash_access_jwt
+```
+
+This site's Cloudflare Access authenticator does not expose EmDash OAuth Device
+Flow, so `emdash login` cannot create a stored CLI session. An approved Access
+service token may be supplied as custom headers instead of the short-lived
+Access JWT.
+
+Treat the repair as successful only when the JSON result reports
+`"status": "complete"`, every collection is complete, and
+`failedSourceCount` is zero. Rerun the repair after any later migration that
+changes media references.
+
 ## Post-Launch State
 
 - WordPress migration scripts and parity tooling have been removed.

--- a/docs/launch-checklist.md
+++ b/docs/launch-checklist.md
@@ -27,17 +27,32 @@ emdash_access_jwt="$(
   cloudflared access token \
     --app https://www.engagedphilosophy.com/_emdash/
 )"
+export EMDASH_HEADERS="Cf-Access-Token: ${emdash_access_jwt}"
 pnpm exec emdash media repair-usage --all \
   --url https://www.engagedphilosophy.com \
-  --header "Cf-Access-Token: ${emdash_access_jwt}" \
   --json
-unset emdash_access_jwt
+unset EMDASH_HEADERS emdash_access_jwt
 ```
 
 This site's Cloudflare Access authenticator does not expose EmDash OAuth Device
-Flow, so `emdash login` cannot create a stored CLI session. An approved Access
-service token may be supplied as custom headers instead of the short-lived
-Access JWT.
+Flow, so `emdash login` cannot create a stored CLI session.
+
+For noninteractive use with an approved Access service token, read the
+credentials without echoing or placing them in shell history, then provide the
+two standard headers through EmDash's environment variable:
+
+```sh
+read -r -p "Cloudflare Access client ID: " emdash_access_client_id
+read -r -s -p "Cloudflare Access client secret: " emdash_access_client_secret
+printf "\n"
+export EMDASH_HEADERS="$(
+  printf "CF-Access-Client-Id: %s\nCF-Access-Client-Secret: %s" \
+    "${emdash_access_client_id}" \
+    "${emdash_access_client_secret}"
+)"
+# Run the same pnpm exec emdash media repair-usage command shown above.
+unset EMDASH_HEADERS emdash_access_client_id emdash_access_client_secret
+```
 
 Treat the repair as successful only when the JSON result reports
 `"status": "complete"`, every collection is complete, and


### PR DESCRIPTION
## Summary

- document the native EmDash media-usage repair required after direct content migrations or bulk rewrites
- include the Cloudflare Access authentication flow used by this deployment
- document the structured success checks and the need to rerun after later media-reference migrations

## Production repair

Ran the native repair against production after recording a D1 Time Travel restore point:

```text
status: complete
sources indexed: 292
pages: 37
posts: 84
projects: 171
failed: 0
skipped: 0
```

Post-repair database verification found 292 indexed sources and 405 media usage references. All 405 local references resolve to media records. Native EmDash usage responses report complete coverage and the expected content for representative media owned by a page, post, and project.

This is a bounded maintenance operation and adds no ongoing Worker requests, storage, or paid Cloudflare features.

## Testing

- `pnpm run ci`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added post-migration maintenance guidance for Cloudflare Access authentication.
  * Documented how to repair media usage after migrations that bypass the content API.
  * Added command instructions, authentication constraints, and success criteria for verifying repairs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->