### PR TITLE
Use native EmDash project URLs

### DIFF
--- a/.emdash/seed.json
+++ b/.emdash/seed.json
@@ -161,13 +161,6 @@
 					"searchable": true
 				},
 				{
-					"slug": "path",
-					"label": "Path",
-					"type": "string",
-					"unique": true,
-					"widget": "legacy-image-blocks:hidden"
-				},
-				{
 					"slug": "excerpt",
 					"label": "Excerpt",
 					"type": "portableText",

--- a/.emdash/seed.json
+++ b/.emdash/seed.json
@@ -151,6 +151,7 @@
 			"label": "Projects",
 			"labelSingular": "Project",
 			"supports": ["drafts", "revisions", "search"],
+			"urlPattern": "/project/{slug}",
 			"fields": [
 				{
 					"slug": "title",

--- a/docs/emdash-customizations.md
+++ b/docs/emdash-customizations.md
@@ -68,13 +68,22 @@ consuming the smaller KV write budget or requiring a paid service.
   prefetches. The project index still requests counts intentionally for its
   topic cloud; other public pages no longer pay for the assignment-table
   aggregate, which reduces D1 rows read on Workers Free.
+- Projects declare EmDash's native `/project/{slug}` collection URL pattern
+  instead of persisting an identical imported `path` field. EmDash can
+  therefore generate project references and automatic redirects after slug
+  changes. The Astro `/projects/{id-or-slug}` compatibility route remains
+  because EmDash preview URLs use it and the signed `_preview` query parameter
+  must survive the redirect. The legacy root-slug alias also remains; replacing
+  either route with one exact redirect row per project would increase cold
+  redirect-cache reads on Workers Free.
 - The base layout uses `EmDashHead`, `EmDashBodyStart`, and `EmDashBodyEnd` so
   EmDash SEO settings and plugin page contributions are rendered through the
   standard pipeline.
-- The sitemap remains site-specific because imported WordPress posts use a
-  stored `path` such as `2022/05/31/post-slug`. EmDash collection URL patterns
-  can interpolate an entry slug or ID, but cannot interpolate this custom path.
-  The custom sitemap still honors EmDash noindex and canonical settings.
+- The sitemap remains site-specific because imported WordPress pages and posts
+  use stored nested paths, such as `2022/05/31/post-slug`. EmDash collection URL
+  patterns can interpolate an entry slug or ID, but cannot interpolate these
+  custom paths. Projects use their native URL pattern in the custom sitemap,
+  which still honors EmDash noindex and canonical settings.
 - Portable Text images use the EmDash renderer. A narrow CSS compatibility
   layer preserves imported float dimensions, centers images when long captions
   widen their figures, and retains left/right placement when floats stack on

--- a/e2e/specs/admin/content-workflows.spec.ts
+++ b/e2e/specs/admin/content-workflows.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from "../../fixtures/worker";
 import { collectPageErrors } from "../../support/assertions";
 import {
 	canonicalAliasForItem,
+	createAndPublishContentViaApi,
 	createAndPublishContentViaAdmin,
 	createContentViaApi,
 	deleteContentViaApi,
@@ -10,6 +11,7 @@ import {
 	getPreviewUrlViaApi,
 	portableTextParagraph,
 	uniqueTitle,
+	updateContentViaApi,
 } from "../../support/content";
 
 interface SavedContentResponse {
@@ -227,6 +229,45 @@ test.describe("admin content workflows", () => {
 			expect(finalUrl.searchParams.get("_preview")).toBe(previewToken);
 		} finally {
 			await deleteContentViaApi(authedRequest, "projects", created.id);
+		}
+	});
+
+	test("redirects a project's old native URL after its slug changes", async ({
+		authedRequest,
+		publicPage,
+	}, testInfo) => {
+		const title = uniqueTitle("E2E Renamed Project", testInfo.testId);
+		const bodyText = `${title} body remains available after renaming.`;
+		const { published, publicPath } = await createAndPublishContentViaApi(
+			authedRequest,
+			"projects",
+			{ title, content: bodyText },
+		);
+		const newSlug = `${published.slug}-renamed`;
+
+		try {
+			const updated = await updateContentViaApi(
+				authedRequest,
+				"projects",
+				published.id,
+				{ slug: newSlug },
+			);
+			expect(updated.slug).toBe(newSlug);
+
+			const redirectResponse = await publicPage.request.get(publicPath, {
+				maxRedirects: 0,
+			});
+			expect(redirectResponse.status()).toBe(301);
+			expect(redirectResponse.headers().location).toBe(`/project/${newSlug}`);
+
+			await expectPublicContent(
+				publicPage,
+				`/project/${newSlug}/`,
+				title,
+				bodyText,
+			);
+		} finally {
+			await deleteContentViaApi(authedRequest, "projects", published.id);
 		}
 	});
 });

--- a/e2e/specs/admin/content-workflows.spec.ts
+++ b/e2e/specs/admin/content-workflows.spec.ts
@@ -189,6 +189,15 @@ test.describe("admin content workflows", () => {
 				`Expected ${alias} to redirect or load`,
 			).toBeLessThan(400);
 			expect(new URL(publicPage.url()).pathname).toBe(publicPath);
+
+			if (collection === "projects") {
+				const rootAlias = `/${published.slug}/`;
+				const rootAliasResponse = await publicPage.request.get(rootAlias, {
+					maxRedirects: 0,
+				});
+				expect(rootAliasResponse.status()).toBe(301);
+				expect(rootAliasResponse.headers().location).toBe(publicPath);
+			}
 		}
 	});
 

--- a/e2e/specs/admin/content-workflows.spec.ts
+++ b/e2e/specs/admin/content-workflows.spec.ts
@@ -7,6 +7,7 @@ import {
 	deleteContentViaApi,
 	dismissWelcome,
 	expectPublicContent,
+	getPreviewUrlViaApi,
 	portableTextParagraph,
 	uniqueTitle,
 } from "../../support/content";
@@ -186,6 +187,46 @@ test.describe("admin content workflows", () => {
 				`Expected ${alias} to redirect or load`,
 			).toBeLessThan(400);
 			expect(new URL(publicPage.url()).pathname).toBe(publicPath);
+		}
+	});
+
+	test("previews a draft project on its canonical route", async ({
+		authedRequest,
+		publicPage,
+	}, testInfo) => {
+		const title = uniqueTitle("E2E Draft Project", testInfo.testId);
+		const bodyText = `${title} body visible only through preview.`;
+		const created = await createContentViaApi(authedRequest, "projects", {
+			title,
+			content: bodyText,
+		});
+
+		try {
+			const preview = await getPreviewUrlViaApi(
+				authedRequest,
+				"projects",
+				created.id,
+			);
+			const requestedUrl = new URL(preview.url, "https://example.test");
+			const previewToken = requestedUrl.searchParams.get("_preview");
+
+			expect(requestedUrl.pathname).toBe(`/projects/${created.id}`);
+			expect(previewToken).toBeTruthy();
+
+			const redirectResponse = await publicPage.request.get(preview.url, {
+				maxRedirects: 0,
+			});
+			expect(redirectResponse.status()).toBe(302);
+			expect(redirectResponse.headers().location).toBe(
+				`/project/${created.slug}/${requestedUrl.search}`,
+			);
+
+			await expectPublicContent(publicPage, preview.url, title, bodyText);
+			const finalUrl = new URL(publicPage.url());
+			expect(finalUrl.pathname).toBe(`/project/${created.slug}/`);
+			expect(finalUrl.searchParams.get("_preview")).toBe(previewToken);
+		} finally {
+			await deleteContentViaApi(authedRequest, "projects", created.id);
 		}
 	});
 });

--- a/e2e/support/content.ts
+++ b/e2e/support/content.ts
@@ -114,7 +114,7 @@ export function publicPathForItem(
 	}
 
 	if (collection === "projects") {
-		return `/${storedPath || `project/${slug}`}/`;
+		return `/project/${slug}/`;
 	}
 
 	const parts = dateParts(item.publishedAt) ?? dateParts(item.createdAt);

--- a/e2e/support/content.ts
+++ b/e2e/support/content.ts
@@ -243,6 +243,18 @@ export async function publishContentViaApi(
 	return body?.data?.item as ContentItem;
 }
 
+export async function getPreviewUrlViaApi(
+	request: APIRequestContext,
+	collection: CollectionSlug,
+	id: string,
+) {
+	const response = await request.post(
+		`/_emdash/api/content/${collection}/${id}/preview-url`,
+	);
+	const body = await expectJsonResponse(response, `preview ${collection}`);
+	return body?.data as { url: string; expiresAt: number };
+}
+
 export async function updateContentViaApi(
 	request: APIRequestContext,
 	collection: CollectionSlug,

--- a/emdash-env.d.ts
+++ b/emdash-env.d.ts
@@ -51,7 +51,6 @@ export interface Project {
   slug: string | null;
   status: string;
   title: string;
-  path?: string;
   excerpt?: PortableTextBlock[];
   content?: PortableTextBlock[];
   featured_image?: { id: string; src?: string; alt?: string; width?: number; height?: number; provider?: string; previewUrl?: string; meta?: Record<string, unknown> };

--- a/src/components/TaxonomyArchive.astro
+++ b/src/components/TaxonomyArchive.astro
@@ -2,6 +2,7 @@
 import EntrySummary from "./content/EntrySummary.astro";
 import Pagination from "./content/Pagination.astro";
 import ThemeSidebar from "./ThemeSidebar.astro";
+import { projectPath } from "../lib/content-paths";
 import {
 	getEntryContent,
 	getEntryExcerpt,
@@ -43,7 +44,7 @@ function pageHref(pageNumber: number) {
 					<EntrySummary
 						articleClass={`mb-5 pb-4 border-bottom ${project.data.featured_image?.src ? "has-post-thumbnail " : ""}project type-project status-publish`}
 						title={project.data.title ?? ""}
-						continueHref={`/${project.data.path}/`}
+						continueHref={`/${projectPath(project.data.slug || project.id)}/`}
 						excerpt={getExcerptText(
 							getEntryExcerpt(project.data),
 							getEntryContent(project.data),

--- a/src/lib/content-paths.ts
+++ b/src/lib/content-paths.ts
@@ -4,7 +4,8 @@ type DateValue = Date | string | number | null | undefined;
 
 // Canonical URL rules mirror the migrated WordPress shape:
 // pages keep their existing parent path and replace only the leaf slug,
-// posts live under YYYY/MM/DD, and projects live under /project/{slug}/.
+// posts live under YYYY/MM/DD, and projects use EmDash's /project/{slug}
+// collection URL pattern.
 export function normalizeContentPath(path?: string | null) {
 	return (path ?? "").replace(/^\/+|\/+$/g, "");
 }
@@ -63,8 +64,7 @@ export function derivePostPath(
 	return dateParts ? [...dateParts, postSlug].join("/") : postSlug;
 }
 
-export function deriveProjectPath(path?: string | null, slug?: string | null) {
-	const normalizedPath = normalizeContentPath(path);
-	const projectSlug = slugFromPath(slug) || slugFromPath(normalizedPath);
-	return projectSlug ? `project/${projectSlug}` : normalizedPath;
+export function projectPath(slug?: string | null) {
+	const projectSlug = slugFromPath(slug);
+	return projectSlug ? `project/${projectSlug}` : "project";
 }

--- a/src/lib/content-visibility.ts
+++ b/src/lib/content-visibility.ts
@@ -8,11 +8,6 @@ export const CONTENT_VISIBILITY_EXCLUSIONS = [
 		reason:
 			"Duplicate imported page superseded by the canonical project guidelines page.",
 	},
-	{
-		path: "project/photos-for-our-furry-friends-2",
-		reason:
-			"Duplicate imported project path superseded by the canonical project entry.",
-	},
 ] as const;
 
 const EXCLUDED_PUBLIC_PATHS: ReadonlySet<string> = new Set(

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -9,7 +9,6 @@ import { isPublicContentPath } from "./content-visibility";
 import {
 	derivePagePath,
 	derivePostPath,
-	deriveProjectPath,
 	normalizeContentPath,
 	slugFromPath,
 } from "./content-paths";
@@ -73,8 +72,6 @@ function normalizeEntry<T extends { featured_image?: RawMediaField | null }>(
 			data.publishedAt,
 			data.createdAt,
 		);
-	} else if (collection === "projects") {
-		data.path = deriveProjectPath(data.path, data.slug || entry.id);
 	}
 
 	return {

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -28,6 +28,7 @@ type RuntimeEntry<T> = ContentEntry<T> & {
 };
 type NormalizedEntryData<T> = Omit<T, "featured_image"> & {
 	featured_image?: MediaField;
+	path?: string;
 };
 type RawMediaField = MediaField & {
 	provider?: string;

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -1,6 +1,7 @@
 import { search as searchEmDash } from "emdash";
 
 import { getPublishedEntriesByIds } from "./content";
+import { projectPath } from "./content-paths";
 import {
 	getEntryContent,
 	getEntryExcerpt,
@@ -95,7 +96,10 @@ export async function searchSite(
 		if (!entry) return [];
 
 		const title = stripHtml(entry.data.title).trim();
-		const path = entry.data.path?.trim() ?? "";
+		const path =
+			collection === "projects"
+				? projectPath(entry.data.slug || entry.id)
+				: (entry.data.path?.trim() ?? "");
 		if (!title || !path) return [];
 
 		return [

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -3,6 +3,7 @@ import NotFound from "../components/NotFound.astro";
 import RichContent from "../components/RichContent.astro";
 import Base from "../layouts/Base.astro";
 import { getPageByPath, getPageBySlug, getProjectBySlug } from "../lib/content";
+import { projectPath } from "../lib/content-paths";
 import { joinPath } from "../lib/path-utils";
 import { getEntryContent } from "../lib/rich-text";
 
@@ -16,8 +17,8 @@ const page =
 
 if (!page) {
 	const project = slugParts.length === 1 ? await getProjectBySlug(path) : null;
-	if (project?.data.path) {
-		return Astro.redirect(`/${project.data.path}/`);
+	if (project) {
+		return Astro.redirect(`/${projectPath(project.data.slug || project.id)}/`);
 	}
 }
 

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -18,7 +18,9 @@ const page =
 if (!page) {
 	const project = slugParts.length === 1 ? await getProjectBySlug(path) : null;
 	if (project) {
-		return Astro.redirect(`/${projectPath(project.data.slug || project.id)}/`);
+		return Astro.redirect(
+			`/${projectPath(project.data.slug || project.id)}/${Astro.url.search}`,
+		);
 	}
 }
 

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -18,8 +18,10 @@ const page =
 if (!page) {
 	const project = slugParts.length === 1 ? await getProjectBySlug(path) : null;
 	if (project) {
+		const status = Astro.url.searchParams.has("_preview") ? 302 : 301;
 		return Astro.redirect(
 			`/${projectPath(project.data.slug || project.id)}/${Astro.url.search}`,
+			status,
 		);
 	}
 }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,6 +3,7 @@ import RichContent from "../components/RichContent.astro";
 import SearchResults from "../components/SearchResults.astro";
 import Base from "../layouts/Base.astro";
 import { getHighlightedProjects, getPageBySlug } from "../lib/content";
+import { projectPath } from "../lib/content-paths";
 import { searchSite } from "../lib/search";
 import {
 	getEntryContent,
@@ -78,7 +79,9 @@ const homeBoxes = home
 													getEntryExcerpt(project.data),
 													getEntryContent(project.data),
 												)}{" "}
-												<a href={`/${project.data.path}/`}>
+												<a
+													href={`/${projectPath(project.data.slug || project.id)}/`}
+												>
 													Continue reading <span class="meta-nav">&rarr;</span>
 												</a>
 											</p>

--- a/src/pages/projects/[slug].astro
+++ b/src/pages/projects/[slug].astro
@@ -7,9 +7,10 @@ const { slug = "" } = Astro.params;
 const project = await getProjectBySlug(slug);
 
 if (project) {
+	const status = Astro.url.searchParams.has("_preview") ? 302 : 301;
 	return Astro.redirect(
-		`/${projectPath(project.data.slug || project.id)}/`,
-		301,
+		`/${projectPath(project.data.slug || project.id)}/${Astro.url.search}`,
+		status,
 	);
 }
 Astro.response.status = 404;

--- a/src/pages/projects/[slug].astro
+++ b/src/pages/projects/[slug].astro
@@ -1,12 +1,16 @@
 ---
 import NotFound from "../../components/NotFound.astro";
 import { getProjectBySlug } from "../../lib/content";
+import { projectPath } from "../../lib/content-paths";
 
 const { slug = "" } = Astro.params;
 const project = await getProjectBySlug(slug);
 
 if (project) {
-	return Astro.redirect(`/${project.data.path}/`, 301);
+	return Astro.redirect(
+		`/${projectPath(project.data.slug || project.id)}/`,
+		301,
+	);
 }
 Astro.response.status = 404;
 ---

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -6,6 +6,7 @@ import {
 	getPublishedPosts,
 	getPublishedProjects,
 } from "../lib/content";
+import { projectPath } from "../lib/content-paths";
 import { SITE_SETTINGS_CACHE_TAG } from "../lib/cache-tags";
 import {
 	PUBLIC_EDGE_CACHE_MAX_AGE_SECONDS,
@@ -19,18 +20,22 @@ import {
 
 interface SitemapSourceEntry {
 	id: string;
-	data: Omit<SitemapInputEntry["data"], "seo"> & { seo?: ContentSeo };
+	data: Omit<SitemapInputEntry["data"], "seo"> & {
+		slug?: string | null;
+		seo?: ContentSeo;
+	};
 }
 
 function toSitemapEntry(
 	entry: SitemapSourceEntry,
 	siteUrl: string,
+	path = entry.data.path,
 ): SitemapInputEntry {
 	return {
 		id: entry.id,
 		image: getSeoMeta(entry, { siteUrl }).ogImage,
 		data: {
-			path: entry.data.path,
+			path,
 			updatedAt: entry.data.updatedAt,
 			publishedAt: entry.data.publishedAt,
 			createdAt: entry.data.createdAt,
@@ -57,7 +62,9 @@ export const GET: APIRoute = async ({ cache, site, url }) => {
 	const body = renderSitemapXml(origin, [
 		...pages.map((entry) => toSitemapEntry(entry, origin)),
 		...posts.map((entry) => toSitemapEntry(entry, origin)),
-		...projects.map((entry) => toSitemapEntry(entry, origin)),
+		...projects.map((entry) =>
+			toSitemapEntry(entry, origin, projectPath(entry.data.slug || entry.id)),
+		),
 	]);
 
 	return new Response(body, {

--- a/tests/unit/content-paths.test.ts
+++ b/tests/unit/content-paths.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from "vitest";
 import {
 	derivePagePath,
 	derivePostPath,
-	deriveProjectPath,
+	projectPath,
 } from "../../src/lib/content-paths";
 
 describe("content path derivation", () => {
@@ -41,13 +41,11 @@ describe("content path derivation", () => {
 		expect(derivePostPath(null, "undated-post")).toBe("undated-post");
 	});
 
-	test("derives project paths under the WordPress project prefix", () => {
-		expect(deriveProjectPath("project/old-project", "new-project")).toBe(
-			"project/new-project",
-		);
-		expect(deriveProjectPath(null, "new-project")).toBe("project/new-project");
-		expect(deriveProjectPath("/project/current-project/", null)).toBe(
+	test("builds project paths from the native URL pattern", () => {
+		expect(projectPath("new-project")).toBe("project/new-project");
+		expect(projectPath("/nested/current-project/")).toBe(
 			"project/current-project",
 		);
+		expect(projectPath(null)).toBe("project");
 	});
 });

--- a/tests/unit/search.test.ts
+++ b/tests/unit/search.test.ts
@@ -46,8 +46,8 @@ describe("site search", () => {
 							edit: {},
 							data: {
 								id: "project-1",
+								slug: "project-one",
 								title: "Project One",
-								path: "project/project-one",
 								featured_image: {
 									src: "https://media.example.com/project-one.jpg",
 									alt: "Project One",

--- a/tests/unit/seed.test.ts
+++ b/tests/unit/seed.test.ts
@@ -7,6 +7,7 @@ interface CheckedInSeed {
 	collections?: Array<{
 		slug?: string;
 		supports?: string[];
+		urlPattern?: string;
 		fields?: Array<{ slug?: string; searchable?: boolean }>;
 	}>;
 	content?: unknown;
@@ -44,6 +45,14 @@ describe("checked-in EmDash seed", () => {
 				true,
 			);
 		}
+	});
+
+	test("uses the native project URL pattern", () => {
+		const projects = seed.collections?.find(
+			(collection) => collection.slug === "projects",
+		);
+
+		expect(projects?.urlPattern).toBe("/project/{slug}");
 	});
 
 	test("indexes the public search fields", () => {

--- a/tests/unit/seed.test.ts
+++ b/tests/unit/seed.test.ts
@@ -53,6 +53,7 @@ describe("checked-in EmDash seed", () => {
 		);
 
 		expect(projects?.urlPattern).toBe("/project/{slug}");
+		expect(projects?.fields?.map((field) => field.slug)).not.toContain("path");
 	});
 
 	test("indexes the public search fields", () => {


### PR DESCRIPTION
## Summary

- configure projects with EmDash's native `/project/{slug}` URL pattern
- remove the redundant imported project `path` field and derive project links from the native pattern
- preserve the `/projects/{id-or-slug}` and root-slug compatibility routes
- retain signed preview query parameters while redirecting draft previews to the canonical project URL
- cover EmDash's automatic redirect when a project slug changes
- document why the remaining compatibility routes are preferable on Cloudflare Workers Free

The compatibility routes remain intentionally. EmDash's exact redirect middleware does not preserve the `_preview` query parameter, and adding one redirect row for every project would increase the D1 rows read whenever a Worker isolate loads the redirect cache.

## Production migration

Production was backed up before mutation with D1 Time Travel bookmark `00000a84-00000024-000050b4-db92685b457622db53d8defc39a69525` and a scoped SQL export. The before-migration map contains 137 published projects; every canonical path already matched `/project/{slug}`, so no legacy URL changes and no new redirect records were needed.

The production migration is complete:

- set the project collection URL pattern through the supported EmDash schema API
- removed `path` from 155 project revision snapshots
- removed the project `path` schema field through the supported API
- verified the live column and revision values are gone
- repaired the project media-usage index: 171 sources indexed, 0 failures, status `complete`
- verified home, project archive/canonical/alias routes, search, sitemap, taxonomy rendering, and the live smoke suite

## Tests

- `pnpm run ci`
- `LIVE_BASE_URL=https://www.engagedphilosophy.com pnpm run smoke:live`

No visual presentation changes are intended, so screenshots are not included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Projects now use the native `/project/{slug}` URL pattern.
  - Project links, search results, sitemaps, previews, and redirects consistently use project slugs.
  - Slug changes automatically redirect old project URLs to the updated URL.
  - Preview links preserve preview state and query parameters.

- **Bug Fixes**
  - Improved project preview routing and redirect behavior.
  - Updated public content exclusions for the latest project content.

- **Documentation**
  - Clarified project URL, preview, redirect, and sitemap behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->