### PR TITLE
Normalize imported media URLs

### DIFF
--- a/docs/emdash-customizations.md
+++ b/docs/emdash-customizations.md
@@ -96,12 +96,13 @@ consuming the smaller KV write budget or requiring a paid service.
   retaining older seed-media shapes or repeating WordPress URL rewrites.
 - Portable Text galleries delegate their markup, image loading, and captions to
   EmDash, and EmDash 0.31 keeps those native gallery blocks visible and editable
-  in the admin editor. A small public-rendering adapter resolves migrated image
-  references to the public R2 domain and preserves imported shortcode/figure
-  layouts. CSP-safe column classes replace EmDash's inline `--columns` property
-  because the production policy intentionally rejects inline styles. This
-  avoids both Worker media proxy requests and Cloudflare image transformations
-  on the Free plan.
+  in the admin editor. Imported gallery URLs are normalized to the public R2
+  domain in both live content and revisions, so the site can pass each gallery
+  directly to EmDash without a per-image URL adapter. The outer compatibility
+  wrapper preserves imported shortcode/figure layouts, while CSP-safe column
+  classes replace EmDash's inline `--columns` property because the production
+  policy intentionally rejects inline styles. This avoids both Worker media
+  proxy requests and Cloudflare image transformations on the Free plan.
 - Imported numbered headings use EmDash's native Portable Text list and heading
   rendering. A CSS counter preserves interview numbering across the answer
   blocks between headings without changing ordinary ordered lists.
@@ -116,9 +117,10 @@ consuming the smaller KV write budget or requiring a paid service.
   lists. EmDash does not support Animoto or the page-list behavior. Its
   self-hosted embed currently forces videos into 16:9 and omits intrinsic
   dimensions and `playsinline`, while its media component serves local files
-  through the Worker. Keeping the small video adapter therefore preserves the
-  square and portrait videos and direct public-R2 delivery on the Cloudflare
-  Free plan.
+  through the Worker. Imported legacy-video URLs are normalized to the public R2
+  domain, so the remaining presentation adapter only validates the URL and
+  preserves square and portrait videos, intrinsic dimensions, `playsinline`,
+  and direct public-R2 delivery on the Cloudflare Free plan.
 
 ## Imported Field Names
 

--- a/e2e/specs/public/legacy-rendering.spec.ts
+++ b/e2e/specs/public/legacy-rendering.spec.ts
@@ -82,18 +82,10 @@ test.describe("public migrated content rendering", () => {
 									_key: `gallery-${index + 1}`,
 									asset: {
 										_ref: `${MEDIA_BASE}${url}`,
-										url,
+										url: `${MEDIA_BASE}${url}`,
 									},
 									alt: `Gallery image ${index + 1}`,
 								})),
-								{
-									_type: "image",
-									_key: "legacy-gallery-unsafe",
-									asset: {
-										url: "javascript:alert(1)",
-									},
-									alt: "Unsafe legacy gallery image",
-								},
 							],
 						},
 						{
@@ -108,7 +100,7 @@ test.describe("public migrated content rendering", () => {
 									_key: `figure-gallery-${index + 1}`,
 									asset: {
 										_ref: `${MEDIA_BASE}${url}`,
-										url,
+										url: `${MEDIA_BASE}${url}`,
 									},
 									alt: `Figure gallery image ${index + 1}`,
 									...(index === 0
@@ -120,14 +112,6 @@ test.describe("public migrated content rendering", () => {
 												}
 											: {}),
 								})),
-								{
-									_type: "image",
-									_key: "legacy-block-gallery-unsafe",
-									asset: {
-										url: "javascript:alert(1)",
-									},
-									alt: "Unsafe legacy block gallery image",
-								},
 							],
 						},
 						{
@@ -141,7 +125,7 @@ test.describe("public migrated content rendering", () => {
 									_key: `lead-gallery-${index + 1}`,
 									asset: {
 										_ref: `${MEDIA_BASE}${url}`,
-										url,
+										url: `${MEDIA_BASE}${url}`,
 									},
 									alt: `Lead gallery image ${index + 1}`,
 								}),
@@ -156,7 +140,7 @@ test.describe("public migrated content rendering", () => {
 						{
 							_type: "legacyVideo",
 							_key: "legacy-video",
-							url: LEGACY_VIDEO_PATH,
+							url: `${MEDIA_BASE}${LEGACY_VIDEO_PATH}`,
 							title: videoTitle,
 							mimeType: "video/mp4",
 							width: 640,
@@ -204,9 +188,6 @@ test.describe("public migrated content rendering", () => {
 			".legacy-gallery-compat--shortcode.legacy-gallery-compat--columns-2 .emdash-gallery",
 		);
 		await expect(gallery.locator("img")).toHaveCount(2);
-		await expect(
-			publicPage.getByAltText("Unsafe legacy gallery image"),
-		).toHaveCount(0);
 		await expect(gallery.locator("img").first()).toHaveAttribute(
 			"src",
 			`${MEDIA_BASE}${GALLERY_PATHS[0]}`,
@@ -229,9 +210,6 @@ test.describe("public migrated content rendering", () => {
 			":scope > .emdash-gallery",
 		);
 		await expect(blockGallery.locator("img")).toHaveCount(4);
-		await expect(
-			publicPage.getByAltText("Unsafe legacy block gallery image"),
-		).toHaveCount(0);
 		await expect(
 			blockGallery.evaluate((element) => {
 				const style = getComputedStyle(element);
@@ -306,6 +284,11 @@ test.describe("public migrated content rendering", () => {
 			"src",
 			`${MEDIA_BASE}${LEGACY_VIDEO_PATH}`,
 		);
+		await expect(
+			publicPage.locator(
+				'[src^="/_emdash/api/media/file/wp-content/uploads/"]',
+			),
+		).toHaveCount(0);
 		await expectPageTextNotToContain(publicPage, "[gallery");
 		await expectPageTextNotToContain(publicPage, "[youtube");
 		await expectPageTextNotToContain(publicPage, "[playlist");

--- a/e2e/specs/public/legacy-rendering.spec.ts
+++ b/e2e/specs/public/legacy-rendering.spec.ts
@@ -86,6 +86,14 @@ test.describe("public migrated content rendering", () => {
 									},
 									alt: `Gallery image ${index + 1}`,
 								})),
+								{
+									_type: "image",
+									_key: "legacy-gallery-unsafe",
+									asset: {
+										url: "javascript:alert(1)",
+									},
+									alt: "Unsafe legacy gallery image",
+								},
 							],
 						},
 						{
@@ -112,6 +120,14 @@ test.describe("public migrated content rendering", () => {
 												}
 											: {}),
 								})),
+								{
+									_type: "image",
+									_key: "legacy-block-gallery-unsafe",
+									asset: {
+										url: "javascript:alert(1)",
+									},
+									alt: "Unsafe legacy block gallery image",
+								},
 							],
 						},
 						{
@@ -142,6 +158,15 @@ test.describe("public migrated content rendering", () => {
 							_key: "legacy-video",
 							url: `${MEDIA_BASE}${LEGACY_VIDEO_PATH}`,
 							title: videoTitle,
+							mimeType: "video/mp4",
+							width: 640,
+							height: 360,
+						},
+						{
+							_type: "legacyVideo",
+							_key: "legacy-video-relative",
+							url: LEGACY_VIDEO_PATH,
+							title: "Unnormalized imported video",
 							mimeType: "video/mp4",
 							width: 640,
 							height: 360,
@@ -188,6 +213,9 @@ test.describe("public migrated content rendering", () => {
 			".legacy-gallery-compat--shortcode.legacy-gallery-compat--columns-2 .emdash-gallery",
 		);
 		await expect(gallery.locator("img")).toHaveCount(2);
+		await expect(
+			publicPage.getByAltText("Unsafe legacy gallery image"),
+		).toHaveCount(0);
 		await expect(gallery.locator("img").first()).toHaveAttribute(
 			"src",
 			`${MEDIA_BASE}${GALLERY_PATHS[0]}`,
@@ -210,6 +238,9 @@ test.describe("public migrated content rendering", () => {
 			":scope > .emdash-gallery",
 		);
 		await expect(blockGallery.locator("img")).toHaveCount(4);
+		await expect(
+			publicPage.getByAltText("Unsafe legacy block gallery image"),
+		).toHaveCount(0);
 		await expect(
 			blockGallery.evaluate((element) => {
 				const style = getComputedStyle(element);
@@ -284,6 +315,7 @@ test.describe("public migrated content rendering", () => {
 			"src",
 			`${MEDIA_BASE}${LEGACY_VIDEO_PATH}`,
 		);
+		await expect(publicPage.locator(".legacy-video")).toHaveCount(1);
 		await expect(
 			publicPage.locator(
 				'[src^="/_emdash/api/media/file/wp-content/uploads/"]',

--- a/src/components/rich-text/RichTextGallery.astro
+++ b/src/components/rich-text/RichTextGallery.astro
@@ -2,15 +2,22 @@
 import { Gallery as EmDashGallery } from "emdash/ui";
 
 import type { RichTextGalleryNode } from "../../lib/rich-text-types";
+import { safeUrlForMediaSrc } from "../../lib/url-safety";
 
 interface Props {
 	node: RichTextGalleryNode;
 }
 
 const { node } = Astro.props;
+const images = node.images.flatMap((image) => {
+	if (!image.asset.url) return [image];
+
+	const url = safeUrlForMediaSrc(image.asset.url);
+	return url ? [{ ...image, asset: { ...image.asset, url } }] : [];
+});
 const usesLeadLayout =
-	node.layout === "shortcode" && node.columns === 3 && node.images.length === 4;
-const firstImage = node.images[0];
+	node.layout === "shortcode" && node.columns === 3 && images.length === 4;
+const firstImage = images[0];
 const hasSeparateCaption = Boolean(
 	node.caption && firstImage && firstImage.caption,
 );
@@ -18,12 +25,9 @@ const galleryNode =
 	node.caption && firstImage && !firstImage.caption
 		? {
 				...node,
-				images: [
-					{ ...firstImage, caption: node.caption },
-					...node.images.slice(1),
-				],
+				images: [{ ...firstImage, caption: node.caption }, ...images.slice(1)],
 			}
-		: node;
+		: { ...node, images };
 ---
 
 <div

--- a/src/components/rich-text/RichTextGallery.astro
+++ b/src/components/rich-text/RichTextGallery.astro
@@ -1,7 +1,6 @@
 ---
 import { Gallery as EmDashGallery } from "emdash/ui";
 
-import { getAssetSrc } from "../../lib/media";
 import type { RichTextGalleryNode } from "../../lib/rich-text-types";
 
 interface Props {
@@ -9,24 +8,9 @@ interface Props {
 }
 
 const { node } = Astro.props;
-const getPublicMediaUrl = Astro.locals.emdash?.getPublicMediaUrl;
-const images = node.images
-	.map((image) => {
-		const src = getAssetSrc(image.asset, undefined, getPublicMediaUrl);
-		if (!src) return null;
-		return {
-			...image,
-			alt: image.alt || image.caption || "",
-			asset: {
-				...image.asset,
-				url: src,
-			},
-		};
-	})
-	.filter((image) => image !== null);
 const usesLeadLayout =
-	node.layout === "shortcode" && node.columns === 3 && images.length === 4;
-const firstImage = images[0];
+	node.layout === "shortcode" && node.columns === 3 && node.images.length === 4;
+const firstImage = node.images[0];
 const hasSeparateCaption = Boolean(
 	node.caption && firstImage && firstImage.caption,
 );
@@ -34,9 +18,12 @@ const galleryNode =
 	node.caption && firstImage && !firstImage.caption
 		? {
 				...node,
-				images: [{ ...firstImage, caption: node.caption }, ...images.slice(1)],
+				images: [
+					{ ...firstImage, caption: node.caption },
+					...node.images.slice(1),
+				],
 			}
-		: { ...node, images };
+		: node;
 ---
 
 <div

--- a/src/components/rich-text/RichTextVideo.astro
+++ b/src/components/rich-text/RichTextVideo.astro
@@ -1,14 +1,13 @@
 ---
-import { getAssetSrc } from "../../lib/media";
 import type { RichTextVideoNode } from "../../lib/rich-text-types";
+import { safeUrlForMediaSrc } from "../../lib/url-safety";
 
 interface Props {
 	node: RichTextVideoNode;
 }
 
 const { node } = Astro.props;
-const getPublicMediaUrl = Astro.locals.emdash?.getPublicMediaUrl;
-const src = getAssetSrc(null, node.url, getPublicMediaUrl);
+const src = safeUrlForMediaSrc(node.url);
 ---
 
 {

--- a/src/components/rich-text/RichTextVideo.astro
+++ b/src/components/rich-text/RichTextVideo.astro
@@ -7,7 +7,8 @@ interface Props {
 }
 
 const { node } = Astro.props;
-const src = safeUrlForMediaSrc(node.url);
+const safeSrc = safeUrlForMediaSrc(node.url);
+const src = safeSrc.startsWith("https://") ? safeSrc : "";
 ---
 
 {

--- a/src/lib/media.ts
+++ b/src/lib/media.ts
@@ -1,31 +1,13 @@
 import { env as cloudflareEnv } from "cloudflare:workers";
 
-import { PUBLIC_MEDIA_URL, WORDPRESS_SITE_URL } from "./site-config";
-import { safeUrlForMediaSrc } from "./url-safety";
+import { PUBLIC_MEDIA_URL } from "./site-config";
 
-export { PUBLIC_MEDIA_URL, WORDPRESS_SITE_URL };
+export { PUBLIC_MEDIA_URL };
 
 const EMDASH_MEDIA_FILE_PREFIX = "/_emdash/api/media/file/";
 
 function normalizeMediaHost(value: string) {
 	return value.replace(/\/+$/, "");
-}
-
-function sanitizeUploadPath(pathname: string) {
-	return pathname
-		.split("/")
-		.map((segment) => segment.replace(/\.\.+/g, "."))
-		.join("/");
-}
-
-export function isWordPressUploadUrl(value?: string | null) {
-	const normalized = (value ?? "").trim();
-	return (
-		normalized.startsWith("/wp-content/uploads/") ||
-		/^https?:\/\/(?:www\.|media\.)?engagedphilosophy\.com\/wp-content\/uploads\//i.test(
-			normalized,
-		)
-	);
 }
 
 function getInternalMediaKey(value?: string | null) {
@@ -39,72 +21,6 @@ function getInternalMediaKey(value?: string | null) {
 	} catch {
 		return encodedKey;
 	}
-}
-
-function getStorageKeyFromMeta(meta?: Record<string, unknown> | null) {
-	return typeof meta?.storageKey === "string" ? meta.storageKey : "";
-}
-
-function resolvePublicMediaUrl(
-	key: string,
-	getPublicMediaUrl?: ((key: string) => string) | null,
-) {
-	if (!key) return "";
-	let resolvedUrl = "";
-
-	if (getPublicMediaUrl) {
-		try {
-			resolvedUrl = getPublicMediaUrl(key) || "";
-		} catch (e) {
-			console.error("Failed to resolve public media URL:", e);
-		}
-	}
-
-	if (resolvedUrl && !resolvedUrl.startsWith(EMDASH_MEDIA_FILE_PREFIX)) {
-		const safeResolvedUrl = safeUrlForMediaSrc(resolvedUrl);
-		if (safeResolvedUrl) return safeResolvedUrl;
-	}
-
-	return getPublicMediaStorageUrl(key);
-}
-
-function isPublicMediaRef(value?: string | null) {
-	return Boolean(value && !value.includes("/") && !value.startsWith("http"));
-}
-
-export function getAssetSrc(
-	asset?: {
-		_ref?: string;
-		url?: string;
-		meta?: Record<string, unknown>;
-	} | null,
-	fallbackUrl?: string | null,
-	getPublicMediaUrl?: ((key: string) => string) | null,
-) {
-	const url = asset?.url ?? fallbackUrl ?? "";
-	const storageKey =
-		getStorageKeyFromMeta(asset?.meta) ||
-		getInternalMediaKey(asset?.url) ||
-		getInternalMediaKey(fallbackUrl);
-	const resolvedStorageUrl = resolvePublicMediaUrl(
-		storageKey,
-		getPublicMediaUrl,
-	);
-	if (resolvedStorageUrl) return resolvedStorageUrl;
-
-	const mediaRefUrl = asset?._ref
-		? resolvePublicMediaUrl(
-				isPublicMediaRef(asset._ref) ? asset._ref : "",
-				getPublicMediaUrl,
-			)
-		: "";
-	if (mediaRefUrl) return mediaRefUrl;
-
-	if (isWordPressUploadUrl(url)) {
-		return rewriteWordPressUploadUrl(url, getMediaUrlPrefix());
-	}
-
-	return safeUrlForMediaSrc(url);
 }
 
 export function getMediaUrlPrefix(
@@ -136,43 +52,4 @@ export function rewriteInternalMediaFileUrl(
 	return storageKey
 		? getPublicMediaStorageUrl(storageKey, mediaUrlPrefix)
 		: (value ?? "");
-}
-
-export function rewriteWordPressUploadUrl(
-	value?: string | null,
-	mediaUrlPrefix = WORDPRESS_SITE_URL,
-) {
-	const normalized = (value ?? "").trim();
-	if (!normalized) return "";
-	const internalMediaUrl = rewriteInternalMediaFileUrl(
-		normalized,
-		mediaUrlPrefix,
-	);
-	if (internalMediaUrl !== normalized) return internalMediaUrl;
-
-	const normalizedPrefix = normalizeMediaHost(mediaUrlPrefix);
-	const shouldSanitize = normalizedPrefix !== WORDPRESS_SITE_URL;
-
-	if (normalized.startsWith("/wp-content/uploads/")) {
-		const pathname = shouldSanitize
-			? sanitizeUploadPath(normalized)
-			: normalized;
-		return `${normalizedPrefix}${pathname}`;
-	}
-	try {
-		const url = new URL(normalized);
-		if (
-			/^(?:www\.|media\.)?engagedphilosophy\.com$/i.test(url.hostname) &&
-			url.pathname.startsWith("/wp-content/uploads/")
-		) {
-			const pathname = shouldSanitize
-				? sanitizeUploadPath(url.pathname)
-				: url.pathname;
-			return `${normalizedPrefix}${pathname}${url.search}${url.hash}`;
-		}
-	} catch {
-		return normalized;
-	}
-
-	return normalized;
 }

--- a/src/lib/site-config.ts
+++ b/src/lib/site-config.ts
@@ -1,7 +1,6 @@
 export const SITE_TITLE_FALLBACK = "Engaged Philosophy";
 export const SITE_TAGLINE_FALLBACK = "Civic Engagement in Philosophy Classes";
 export const PUBLIC_SITE_URL = "https://www.engagedphilosophy.com";
-export const WORDPRESS_SITE_URL = PUBLIC_SITE_URL;
 export const PUBLIC_MEDIA_URL = "https://media.engagedphilosophy.com";
 export const CLOUDFLARE_ACCESS_TEAM_DOMAIN =
 	"engaged-philosophy.cloudflareaccess.com";

--- a/tests/unit/media.test.ts
+++ b/tests/unit/media.test.ts
@@ -1,45 +1,18 @@
 import { describe, expect, test } from "vitest";
 
 import {
-	getAssetSrc,
 	getPublicMediaStorageUrl,
 	rewriteInternalMediaFileUrl,
-	rewriteWordPressUploadUrl,
 } from "../../src/lib/media";
 
 describe("media URL helpers", () => {
-	test("filters unsafe fallback media URLs", () => {
-		expect(getAssetSrc(null, "javascript:alert(1)")).toBe("");
-		expect(getAssetSrc(null, "data:image/svg+xml,<svg></svg>")).toBe("");
-		expect(getAssetSrc(null, "#image")).toBe("");
-	});
-
-	test("preserves safe fallback media URLs", () => {
-		expect(getAssetSrc(null, "/media/photo.jpg")).toBe("/media/photo.jpg");
-		expect(getAssetSrc(null, "https://media.example/photo.jpg")).toBe(
-			"https://media.example/photo.jpg",
-		);
-		expect(getAssetSrc(null, "http://media.example/photo.jpg")).toBe("");
-	});
-
-	test("rewrites WordPress upload URLs to the public media host", () => {
+	test("builds public storage URLs", () => {
 		expect(
-			rewriteWordPressUploadUrl(
-				"/wp-content/uploads/2024/05/photo.jpg",
-				"https://media.engagedphilosophy.com",
+			getPublicMediaStorageUrl(
+				"wp-content/uploads/2024/05/photo name.jpg",
+				"https://media.example/",
 			),
-		).toBe(
-			"https://media.engagedphilosophy.com/wp-content/uploads/2024/05/photo.jpg",
-		);
-		expect(
-			getAssetSrc(
-				null,
-				"/wp-content/uploads/2024/05/photo.jpg",
-				(key) => `https://media.engagedphilosophy.com/${key}`,
-			),
-		).toBe(
-			"https://media.engagedphilosophy.com/wp-content/uploads/2024/05/photo.jpg",
-		);
+		).toBe("https://media.example/wp-content/uploads/2024/05/photo%20name.jpg");
 	});
 
 	test("rewrites internal media file URLs and tolerates malformed encodings", () => {
@@ -61,17 +34,5 @@ describe("media URL helpers", () => {
 				"https://media.example",
 			),
 		).toBe("https://media.example/wp-content/uploads/%25ZZ/photo.jpg");
-	});
-
-	test("falls back to public storage URL when resolver output is unsafe", () => {
-		const key = "wp-content/uploads/2024/05/photo.jpg";
-
-		expect(
-			getAssetSrc(
-				{ meta: { storageKey: key } },
-				null,
-				() => "javascript:alert(1)",
-			),
-		).toBe(getPublicMediaStorageUrl(key));
 	});
 });


### PR DESCRIPTION
## Summary

- pass normalized gallery blocks directly to EmDash while retaining the imported layout/CSP compatibility wrapper
- validate normalized legacy-video URLs without the WordPress/media resolver
- remove the obsolete WordPress URL configuration and resolver tests
- document the smaller remaining compatibility surface

This removes 192 net lines and keeps gallery/video requests on the public R2 domain, avoiding Worker media-proxy and image-transformation work on Cloudflare Workers Free.

## Production migration

- created D1 Time Travel bookmark `00000a84-000002d4-000050b4-1975a0fc0a55a2b5131c379a8e27efa4` and a scoped SQL backup
- rehearsed the guarded migration against a local restore
- updated 260 guarded live/revision rows in production
- normalized 571 live gallery images, 8 live legacy videos, 639 revision gallery images, and 8 revision legacy videos
- independently audited zero remaining gallery/video proxy URLs
- rebuilt media usage for all 292 sources with zero failures

## Validation

- `pnpm run ci`
- `pnpm run smoke:live`
- live 200/direct-media checks for:
  - `/about-ce-projects/about-e-portfolios/`
  - `/students/st-catherine-university/`
  - `/project/3119/`
  - `/project/raffle-to-raise-funds-for-feminine-hygiene-products/`

The Worker-backed gallery coverage checks desktop columns and wrapping, imported captions, lead/orphan sizing, direct R2 sources, and mobile single-column behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved rendering of migrated galleries and legacy videos with normalized public media URLs.
  - Prevented unsafe or invalid gallery image URLs from being displayed.
  - Ensured legacy videos use secure HTTPS sources and avoid unnecessary media proxy requests.
  - Improved compatibility with Cloudflare Free plan delivery and content security policies.

- **Documentation**
  - Updated public rendering guidance for migrated galleries and legacy video embeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->