### PR TITLE
schema: remove unused migration fields

### DIFF
--- a/.emdash/seed.json
+++ b/.emdash/seed.json
@@ -55,12 +55,6 @@
 					"type": "string"
 				},
 				{
-					"slug": "about_html",
-					"label": "About HTML",
-					"type": "portableText",
-					"widget": "portableText"
-				},
-				{
 					"slug": "box_left_title",
 					"label": "Left Box Title",
 					"type": "string"
@@ -92,11 +86,6 @@
 					"label": "Right Box HTML",
 					"type": "portableText",
 					"widget": "portableText"
-				},
-				{
-					"slug": "legacy_wp_id",
-					"label": "Legacy WordPress ID",
-					"type": "integer"
 				}
 			]
 		},
@@ -138,11 +127,6 @@
 					"slug": "featured_image",
 					"label": "Featured Image",
 					"type": "image"
-				},
-				{
-					"slug": "legacy_wp_id",
-					"label": "Legacy WordPress ID",
-					"type": "integer"
 				}
 			]
 		},
@@ -190,11 +174,6 @@
 					"label": "Menu Order",
 					"type": "integer",
 					"defaultValue": 0
-				},
-				{
-					"slug": "legacy_wp_id",
-					"label": "Legacy WordPress ID",
-					"type": "integer"
 				}
 			]
 		}

--- a/emdash-env.d.ts
+++ b/emdash-env.d.ts
@@ -14,14 +14,12 @@ export interface Page {
   content?: PortableTextBlock[];
   featured_image?: { id: string; src?: string; alt?: string; width?: number; height?: number; provider?: string; previewUrl?: string; meta?: Record<string, unknown> };
   template?: string;
-  about_html?: PortableTextBlock[];
   box_left_title?: string;
   box_left_html?: PortableTextBlock[];
   box_middle_title?: string;
   box_middle_html?: PortableTextBlock[];
   box_right_title?: string;
   box_right_html?: PortableTextBlock[];
-  legacy_wp_id?: number;
   createdAt: Date;
   updatedAt: Date;
   publishedAt: Date | null;
@@ -38,7 +36,6 @@ export interface Post {
   excerpt?: PortableTextBlock[];
   content?: PortableTextBlock[];
   featured_image?: { id: string; src?: string; alt?: string; width?: number; height?: number; provider?: string; previewUrl?: string; meta?: Record<string, unknown> };
-  legacy_wp_id?: number;
   createdAt: Date;
   updatedAt: Date;
   publishedAt: Date | null;
@@ -56,7 +53,6 @@ export interface Project {
   featured_image?: { id: string; src?: string; alt?: string; width?: number; height?: number; provider?: string; previewUrl?: string; meta?: Record<string, unknown> };
   highlight?: boolean;
   menu_order?: number;
-  legacy_wp_id?: number;
   createdAt: Date;
   updatedAt: Date;
   publishedAt: Date | null;

--- a/tests/unit/seed.test.ts
+++ b/tests/unit/seed.test.ts
@@ -56,6 +56,20 @@ describe("checked-in EmDash seed", () => {
 		expect(projects?.fields?.map((field) => field.slug)).not.toContain("path");
 	});
 
+	test("omits unused WordPress migration fields", () => {
+		for (const collection of seed.collections ?? []) {
+			if (!["pages", "posts", "projects"].includes(collection.slug ?? "")) {
+				continue;
+			}
+
+			const fieldSlugs = collection.fields?.map((field) => field.slug);
+			expect(fieldSlugs).not.toContain("legacy_wp_id");
+			if (collection.slug === "pages") {
+				expect(fieldSlugs).not.toContain("about_html");
+			}
+		}
+	});
+
 	test("indexes the public search fields", () => {
 		for (const collection of seed.collections ?? []) {
 			if (!["pages", "posts", "projects"].includes(collection.slug ?? "")) {

--- a/tests/unit/seed.test.ts
+++ b/tests/unit/seed.test.ts
@@ -57,14 +57,18 @@ describe("checked-in EmDash seed", () => {
 	});
 
 	test("omits unused WordPress migration fields", () => {
-		for (const collection of seed.collections ?? []) {
-			if (!["pages", "posts", "projects"].includes(collection.slug ?? "")) {
-				continue;
-			}
-
-			const fieldSlugs = collection.fields?.map((field) => field.slug);
+		for (const slug of ["pages", "posts", "projects"]) {
+			const collection = seed.collections?.find(
+				(candidate) => candidate.slug === slug,
+			);
+			expect(collection, `Missing ${slug} collection`).toBeDefined();
+			expect(
+				collection?.fields?.length,
+				`Missing fields for ${slug} collection`,
+			).toBeGreaterThan(0);
+			const fieldSlugs = collection?.fields?.map((field) => field.slug);
 			expect(fieldSlugs).not.toContain("legacy_wp_id");
-			if (collection.slug === "pages") {
+			if (slug === "pages") {
 				expect(fieldSlugs).not.toContain("about_html");
 			}
 		}


### PR DESCRIPTION
## Summary

- remove the unused `about_html` page field from the checked-in EmDash schema
- remove the migration-only `legacy_wp_id` field from pages, posts, and projects
- regenerate `emdash-env.d.ts` from an isolated EmDash database
- add a seed regression test so the removed fields are not reintroduced

## Production migration

Before changing production, I captured a current D1 Time Travel bookmark and a scoped SQL export, restored that export to an isolated local D1, and rehearsed the revision migration there. The rehearsal changed exactly 308 revisions and preserved valid JSON.

Production has now been migrated through the same guarded revision cleanup and EmDash’s supported schema API:

- removed `legacy_wp_id` from 48 page, 106 post, and 154 project revisions
- removed `about_html` from 48 page revisions
- removed all four live schema fields and their content-table columns
- rebuilt the media-usage indexes EmDash marked stale after the schema changes
- verified zero remaining schema/revision fields and unchanged collection counts

The Home page and representative page, post, and project routes remain healthy. Live cache checks still report hits, and the `philosophy` and `pacific` searches still return results.

## Tests

- `pnpm run ci`
- `LIVE_BASE_URL=https://www.engagedphilosophy.com pnpm run smoke:live`
- focused seed, generated-type, and formatting checks
- production D1 schema, revision, media-index, collection-count, representative-page, and search checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed legacy WordPress migration fields from page, post, and project content models.
  * Removed the obsolete `about_html` page field.
* **Tests**
  * Added validation to ensure these retired fields are excluded from the CMS seed configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->