### PR TITLE
cleanup: remove migration residue

### DIFF
--- a/docs/emdash-customizations.md
+++ b/docs/emdash-customizations.md
@@ -170,10 +170,9 @@ other required values, the route fails closed with `ACCESS_CONFIG_ERROR`.
 
 - `astro.config.mjs` keeps the Vite chunk-size warning limit aligned with the
   admin bundle size while leaving upstream build warnings visible.
-- `wrangler.jsonc` enables Workers Cache with per-deployment version isolation,
-  enables Cloudflare logs/traces, and includes both current and legacy binding
-  names for D1/R2 compatibility. A deployment starts with a cold route cache;
-  stale entries are not reused across Worker versions.
+- `wrangler.jsonc` enables Workers Cache with per-deployment version isolation
+  and enables Cloudflare logs/traces. A deployment starts with a cold route
+  cache; stale entries are not reused across Worker versions.
 
 ## Removal Candidates
 

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
 		"@types/node": "^26.1.2",
 		"@typescript-eslint/eslint-plugin": "^8.65.0",
 		"@typescript-eslint/parser": "^8.65.0",
-		"astro-eslint-parser": "^3.0.0",
 		"eslint": "^10.8.0",
 		"eslint-plugin-astro": "^3.0.1",
 		"playwright": "^1.62.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,9 +86,6 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^8.65.0
         version: 8.65.0(eslint@10.8.0(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
-      astro-eslint-parser:
-        specifier: ^3.0.0
-        version: 3.0.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(supports-color@10.2.2)
       eslint:
         specifier: ^10.8.0
         version: 10.8.0(supports-color@10.2.2)

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -1,6 +1,0 @@
-export * from "./media";
-export * from "./path-utils";
-export * from "./publication-date";
-export * from "./rich-text";
-export * from "./site-config";
-export * from "./taxonomy-utils";

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -48,20 +48,11 @@
 			"database_name": "engaged-philosophy",
 			"database_id": "4fdc5af5-10a0-4aca-9e5f-54db71066fbd",
 		},
-		{
-			"binding": "engaged_philosophy",
-			"database_name": "engaged-philosophy",
-			"database_id": "4fdc5af5-10a0-4aca-9e5f-54db71066fbd",
-		},
 	],
 	"r2_buckets": [
 		{
 			"binding": "MEDIA",
 			"bucket_name": "engaged-philosophy-media",
-		},
-		{
-			"bucket_name": "engaged-philosophy-media",
-			"binding": "engaged_philosophy_media",
 		},
 	],
 	"env": {
@@ -79,20 +70,11 @@
 					"database_name": "engaged-philosophy",
 					"database_id": "4fdc5af5-10a0-4aca-9e5f-54db71066fbd",
 				},
-				{
-					"binding": "engaged_philosophy",
-					"database_name": "engaged-philosophy",
-					"database_id": "4fdc5af5-10a0-4aca-9e5f-54db71066fbd",
-				},
 			],
 			"r2_buckets": [
 				{
 					"binding": "MEDIA",
 					"bucket_name": "engaged-philosophy-media",
-				},
-				{
-					"bucket_name": "engaged-philosophy-media",
-					"binding": "engaged_philosophy_media",
 				},
 			],
 		},


### PR DESCRIPTION
## Summary

- remove the unused src/lib/site.ts export barrel
- stop declaring astro-eslint-parser directly while retaining it through eslint-plugin-astro
- remove the unused legacy D1 and R2 binding aliases from default and production configuration
- update the EmDash customization documentation to match

This reduces migration-era configuration and package surface without adding any Cloudflare features or Free-plan cost.

## Validation

- pnpm install --frozen-lockfile
- pnpm why astro-eslint-parser
- pnpm run lint
- pnpm run build
- pnpm run test:worker-bundle
- pnpm run test:worker-runtime
- wrangler deploy --dry-run --env production
- pnpm run ci

The production dry run exposes only the current DB and MEDIA bindings; the full suite passed, including 37 Worker-backed Playwright tests.