### PR TITLE
search: pilot EmDash AI Search

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,6 +1,7 @@
 import cloudflare from "@astrojs/cloudflare";
 import react from "@astrojs/react";
 import { d1, r2 } from "@emdash-cms/cloudflare";
+import { aiSearch } from "@emdash-cms/cloudflare/plugins";
 import auditLogPlugin from "@emdash-cms/plugin-audit-log";
 import { embedsPlugin } from "@emdash-cms/plugin-embeds";
 import { defineConfig } from "astro/config";
@@ -55,6 +56,14 @@ function localEmDashRoutes() {
 export const emdashPlugins = [
 	auditLogPlugin,
 	embedsPlugin({ types: ["youtube", "vimeo"] }),
+	aiSearch({
+		instanceName: "engaged-philosophy",
+		urlTemplates: {
+			pages: "/pages/{slug}",
+			posts: "/posts/{slug}",
+			projects: "/project/{slug}",
+		},
+	}),
 	{
 		id: "legacy-image-blocks",
 		version: "0.1.0",

--- a/docs/emdash-customizations.md
+++ b/docs/emdash-customizations.md
@@ -162,10 +162,30 @@ other required values, the route fails closed with `ACCESS_CONFIG_ERROR`.
   without Dynamic Worker loaders on the current Cloudflare plan.
 - The upstream embeds plugin registers and renders the enabled YouTube and Vimeo
   blocks directly.
+- The upstream Cloudflare AI Search plugin owns the `engaged-philosophy`
+  instance, initial and incremental indexing, admin controls, result URL
+  generation, and the public search endpoint. The public pilot keeps the
+  conventional EmDash full-text search available and adds only a small
+  CSP-compatible dialog. EmDash's provided snippet currently injects inline
+  styles that the site's public Content Security Policy rejects.
 - `src/plugins/legacy-content-blocks.ts` preserves edit controls for imported
   WordPress-only Portable Text blocks such as playlist videos, remaining legacy
   embeds, and page lists. Its registered plugin ID remains
   `legacy-image-blocks` for compatibility with existing plugin state.
+
+### AI Search pilot setup
+
+After deploying a preview for the first time, open **Plugins -> Cloudflare AI
+Search**, select `pages`, `posts`, and `projects`, and choose **Sync All
+Content**. The plugin indexes later content changes automatically. Preview and
+production use the same named instance in the account's `default` namespace,
+so a preview sync does not need to be repeated after promotion.
+
+Cloudflare AI Search is currently free during its open beta. Workers Free
+allows 20,000 queries per month and 100,000 files per instance; the conventional
+search remains available if AI Search is unavailable or reaches a limit. See
+Cloudflare's [AI Search limits and pricing](https://developers.cloudflare.com/ai-search/platform/limits-pricing/)
+for the current limits.
 
 ## Build Compatibility
 

--- a/docs/emdash-customizations.md
+++ b/docs/emdash-customizations.md
@@ -175,11 +175,15 @@ other required values, the route fails closed with `ACCESS_CONFIG_ERROR`.
 
 ### AI Search pilot setup
 
-After deploying a preview for the first time, open **Plugins -> Cloudflare AI
-Search**, select `pages`, `posts`, and `projects`, and choose **Sync All
-Content**. The plugin indexes later content changes automatically. Preview and
-production use the same named instance in the account's `default` namespace,
-so a preview sync does not need to be repeated after promotion.
+Open **Plugins -> Cloudflare AI Search**, select `pages`, `posts`, and
+`projects`, and choose **Sync All Content**. The plugin indexes later content
+changes automatically. Cloudflare branch previews do not receive Cron Trigger
+events, so an initial sync started from a preview remains queued unless a
+maintainer manually runs that branch's scheduled handler against its remote D1
+and AI Search bindings. The production deployment processes the job normally.
+Preview and production use the same named instance in the account's `default`
+namespace, so a completed preview sync does not need to be repeated after
+promotion.
 
 Cloudflare AI Search is currently free during its open beta. Workers Free
 allows 20,000 queries per month and 100,000 files per instance; the conventional

--- a/e2e/specs/public/client-behavior.spec.ts
+++ b/e2e/specs/public/client-behavior.spec.ts
@@ -16,6 +16,86 @@ test("links skip navigation only to targets present on every page", async ({
 	await expect(publicPage.locator("#content")).toHaveCount(1);
 });
 
+test("opens AI search without replacing conventional search", async ({
+	publicPage,
+}) => {
+	const contentSecurityPolicyErrors: string[] = [];
+	publicPage.on("console", (message) => {
+		if (message.text().includes("Content Security Policy")) {
+			contentSecurityPolicyErrors.push(
+				`${message.text()} ${JSON.stringify(message.location())}`,
+			);
+		}
+	});
+	await publicPage.route("**/api/ai-search/search", async (route) => {
+		expect(route.request().postDataJSON()).toMatchObject({
+			messages: [{ role: "user", content: "community partnerships" }],
+			ai_search_options: { retrieval: { max_num_results: 8 } },
+		});
+		await route.fulfill({
+			contentType: "application/json",
+			body: JSON.stringify({
+				success: true,
+				result: {
+					chunks: [
+						{
+							item: {
+								key: "/pages/community-engagement",
+								metadata: {
+									title: "Community engagement",
+									description: "Philosophy beyond the classroom.",
+								},
+							},
+						},
+					],
+				},
+			}),
+		});
+	});
+
+	const response = await publicPage.goto("/");
+	expect(response?.headers()["content-security-policy"]).toContain(
+		"style-src 'self'",
+	);
+	const baselineContentSecurityPolicyErrors = [...contentSecurityPolicyErrors];
+
+	await expect(publicPage.locator("#searchform")).toBeVisible();
+	const modal = publicPage.locator("[data-ai-search-dialog]");
+	const searchInput = modal.locator("[data-ai-search-query]");
+	await expect(searchInput).toBeHidden();
+	await publicPage.getByRole("button", { name: "AI search" }).click();
+	await expect(searchInput).toBeVisible();
+	await expect(searchInput).toBeFocused();
+
+	await searchInput.fill("community partnerships");
+	await expect(modal.getByRole("status")).toHaveText("1 related result.");
+	await expect(
+		modal.getByRole("link", { name: /Community engagement/ }),
+	).toHaveAttribute("href", "/pages/community-engagement");
+	await expect(
+		modal.getByRole("link", { name: "Use conventional search" }),
+	).toHaveAttribute("href", "/?s=community%20partnerships");
+
+	await modal.getByRole("button", { name: "Close AI search" }).click();
+	await expect(searchInput).toBeHidden();
+	expect(contentSecurityPolicyErrors).toEqual(
+		baselineContentSecurityPolicyErrors,
+	);
+
+	await publicPage.setViewportSize({ width: 390, height: 844 });
+	await publicPage.getByRole("button", { name: "Toggle navigation" }).click();
+	await expect(publicPage.locator("#searchform")).toBeVisible();
+	await publicPage.getByRole("button", { name: "AI search" }).click();
+	await expect(searchInput).toBeVisible();
+
+	const dialogBounds = await modal.boundingBox();
+	expect(dialogBounds).not.toBeNull();
+	expect(dialogBounds!.x).toBeGreaterThanOrEqual(0);
+	expect(dialogBounds!.x + dialogBounds!.width).toBeLessThanOrEqual(390);
+	expect(dialogBounds!.y).toBeGreaterThanOrEqual(0);
+	expect(dialogBounds!.y + dialogBounds!.height).toBeLessThanOrEqual(844);
+});
+
 test("uses Bootstrap data APIs for public theme interactions", async ({
 	authedRequest,
 	publicPage,

--- a/e2e/specs/public/client-behavior.spec.ts
+++ b/e2e/specs/public/client-behavior.spec.ts
@@ -47,6 +47,12 @@ test("opens AI search without replacing conventional search", async ({
 								},
 							},
 						},
+						{
+							item: {
+								key: "https://example.com/not-a-site-result",
+								metadata: { title: "External result" },
+							},
+						},
 					],
 				},
 			}),
@@ -81,6 +87,13 @@ test("opens AI search without replacing conventional search", async ({
 	expect(contentSecurityPolicyErrors).toEqual(
 		baselineContentSecurityPolicyErrors,
 	);
+	await publicPage.getByRole("button", { name: "AI search" }).click();
+	await expect(searchInput).toHaveValue("");
+	await expect(modal.getByRole("status")).toHaveText(
+		"Enter at least two characters to search.",
+	);
+	await expect(modal.locator("[data-ai-search-results] li")).toHaveCount(0);
+	await modal.getByRole("button", { name: "Close AI search" }).click();
 
 	await publicPage.setViewportSize({ width: 390, height: 844 });
 	await publicPage.getByRole("button", { name: "Toggle navigation" }).click();

--- a/e2e/specs/public/client-behavior.spec.ts
+++ b/e2e/specs/public/client-behavior.spec.ts
@@ -28,10 +28,23 @@ test("opens AI search without replacing conventional search", async ({
 		}
 	});
 	await publicPage.route("**/api/ai-search/search", async (route) => {
-		expect(route.request().postDataJSON()).toMatchObject({
-			messages: [{ role: "user", content: "community partnerships" }],
+		const requestBody = route.request().postDataJSON();
+		expect(requestBody).toMatchObject({
 			ai_search_options: { retrieval: { max_num_results: 8 } },
 		});
+
+		if (requestBody.messages[0].content === "unavailable") {
+			await route.fulfill({
+				status: 503,
+				contentType: "application/json",
+				body: JSON.stringify({ success: false }),
+			});
+			return;
+		}
+
+		expect(requestBody.messages).toEqual([
+			{ role: "user", content: "community partnerships" },
+		]);
 		await route.fulfill({
 			contentType: "application/json",
 			body: JSON.stringify({
@@ -93,6 +106,13 @@ test("opens AI search without replacing conventional search", async ({
 		"Enter at least two characters to search.",
 	);
 	await expect(modal.locator("[data-ai-search-results] li")).toHaveCount(0);
+	await searchInput.fill("unavailable");
+	await expect(modal.getByRole("status")).toHaveText(
+		"AI search is temporarily unavailable. Try conventional search instead.",
+	);
+	await expect(
+		modal.getByRole("link", { name: "Use conventional search" }),
+	).toHaveAttribute("href", "/?s=unavailable");
 	await modal.getByRole("button", { name: "Close AI search" }).click();
 
 	await publicPage.setViewportSize({ width: 390, height: 844 });

--- a/e2e/support/worker-server.ts
+++ b/e2e/support/worker-server.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawn, spawnSync, type ChildProcess } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import net from "node:net";
 import path from "node:path";
@@ -62,6 +62,19 @@ function childProcessEnv(extra: NodeJS.ProcessEnv = {}) {
 	delete env.NO_COLOR;
 
 	return env;
+}
+
+function disableRemoteOnlyBindingsForE2E() {
+	const config = JSON.parse(
+		readFileSync(DIST_WRANGLER_CONFIG, "utf8"),
+	) as Record<string, unknown>;
+
+	// Cloudflare does not provide local simulators for AI Search bindings. The
+	// public browser test mocks the managed response, so keep local Worker tests
+	// offline instead of requiring Cloudflare credentials or consuming quota.
+	config.ai_search_namespaces = [];
+	config.ai_search = [];
+	writeFileSync(DIST_WRANGLER_CONFIG, JSON.stringify(config));
 }
 
 function getFreePort() {
@@ -178,6 +191,7 @@ export function buildWorkerForE2E() {
 			"Expected test-auth build to create dist/server/wrangler.json.",
 		);
 	}
+	disableRemoteOnlyBindingsForE2E();
 
 	process.env.EMDASH_E2E_BUILD_READY = "1";
 }

--- a/scripts/check-emdash-types.mjs
+++ b/scripts/check-emdash-types.mjs
@@ -95,6 +95,7 @@ const child = spawn(
 		env: {
 			...process.env,
 			ASTRO_DEV_BACKGROUND: "1",
+			CLOUDFLARE_VITE_FORCE_LOCAL: "true",
 			EMDASH_TYPES_CHECK_STATE: statePath,
 		},
 		stdio: ["ignore", "pipe", "pipe"],

--- a/src/components/AISearchDialog.astro
+++ b/src/components/AISearchDialog.astro
@@ -1,0 +1,53 @@
+<button
+	type="button"
+	class="btn btn-outline-secondary text-nowrap"
+	aria-controls="ai-search-dialog"
+	aria-haspopup="dialog"
+	data-ai-search-open
+>
+	<i class="bi bi-stars" aria-hidden="true"></i> AI search
+</button>
+
+<dialog
+	id="ai-search-dialog"
+	class="ai-search-dialog"
+	aria-labelledby="ai-search-title"
+	data-ai-search-dialog
+	data-api-url="/api/ai-search/search"
+>
+	<div class="ai-search-dialog__panel">
+		<header class="ai-search-dialog__header">
+			<div>
+				<h2 id="ai-search-title" class="h4 mb-1">AI search</h2>
+				<p class="mb-0">Find related content by topic or meaning.</p>
+			</div>
+			<form method="dialog">
+				<button type="submit" class="btn-close" aria-label="Close AI search"
+				></button>
+			</form>
+		</header>
+
+		<div class="ai-search-dialog__body">
+			<label for="ai-search-query" class="visually-hidden"
+				>AI search query</label
+			>
+			<input
+				id="ai-search-query"
+				class="form-control form-control-lg"
+				type="search"
+				placeholder="For example: projects about environmental justice"
+				autocomplete="off"
+				maxlength="200"
+				data-ai-search-query
+			/>
+			<p class="ai-search-dialog__status" role="status" data-ai-search-status>
+				Enter at least two characters to search.
+			</p>
+			<ol class="ai-search-dialog__results" data-ai-search-results></ol>
+		</div>
+
+		<footer class="ai-search-dialog__footer">
+			<a href="/" data-ai-search-fallback>Use conventional search</a>
+		</footer>
+	</div>
+</dialog>

--- a/src/components/layout/PrimaryNav.astro
+++ b/src/components/layout/PrimaryNav.astro
@@ -1,6 +1,8 @@
 ---
 import type { MenuItem } from "emdash";
 
+import AISearchDialog from "../AISearchDialog.astro";
+
 interface Props {
 	menuItems: MenuItem[];
 	currentPath: string;
@@ -88,31 +90,34 @@ function isCurrentUrl(url: string) {
 					}
 				</ul>
 			</div>
-			<form
-				id="searchform"
-				class="d-flex ms-auto"
-				method="get"
-				action="/"
-				role="search"
-				aria-label="Search the site"
-			>
-				<label for="s" class="visually-hidden">Search</label>
-				<input
-					type="search"
-					class="form-control"
-					name="s"
-					id="s"
-					placeholder="Search"
+			<div class="site-search-controls d-flex flex-wrap gap-2 ms-auto">
+				<form
+					id="searchform"
+					class="d-flex flex-grow-1"
+					method="get"
+					action="/"
+					role="search"
 					aria-label="Search the site"
-				/>
-				<button
-					type="submit"
-					class="btn btn-outline-secondary ms-1"
-					aria-label="Submit search"
 				>
-					<i class="bi bi-search"></i>
-				</button>
-			</form>
+					<label for="s" class="visually-hidden">Search</label>
+					<input
+						type="search"
+						class="form-control"
+						name="s"
+						id="s"
+						placeholder="Search"
+						aria-label="Search the site"
+					/>
+					<button
+						type="submit"
+						class="btn btn-outline-secondary ms-1"
+						aria-label="Submit search"
+					>
+						<i class="bi bi-search"></i>
+					</button>
+				</form>
+				<AISearchDialog />
+			</div>
 		</div>
 	</div>
 </nav>

--- a/src/js/ai-search-dialog.ts
+++ b/src/js/ai-search-dialog.ts
@@ -39,6 +39,7 @@ function resultUrl(value: string): URL | null {
 
 function renderResults(container: HTMLOListElement, chunks: AISearchChunk[]) {
 	container.replaceChildren();
+	let renderedCount = 0;
 
 	for (const chunk of chunks) {
 		const url = resultUrl(chunk.item.key);
@@ -60,7 +61,10 @@ function renderResults(container: HTMLOListElement, chunks: AISearchChunk[]) {
 		link.appendChild(path);
 		item.appendChild(link);
 		container.appendChild(item);
+		renderedCount += 1;
 	}
+
+	return renderedCount;
 }
 
 function initializeAISearch(dialog: HTMLDialogElement) {
@@ -100,7 +104,8 @@ function initializeAISearch(dialog: HTMLDialogElement) {
 	}
 
 	async function search(query: string) {
-		activeRequest = new AbortController();
+		const controller = new AbortController();
+		activeRequest = controller;
 		status.textContent = "Searching...";
 		results.replaceChildren();
 
@@ -114,21 +119,29 @@ function initializeAISearch(dialog: HTMLDialogElement) {
 						retrieval: { max_num_results: SEARCH_RESULT_LIMIT },
 					},
 				}),
-				signal: activeRequest.signal,
+				signal: controller.signal,
 			});
 			const body = (await response.json()) as AISearchResponse;
 			if (!response.ok || !body.success) throw new Error("AI search failed");
+			if (activeRequest !== controller) return;
 
 			const chunks = body.result?.chunks ?? [];
-			renderResults(results, chunks);
+			const renderedCount = renderResults(results, chunks);
 			status.textContent =
-				chunks.length === 0
+				renderedCount === 0
 					? "No related content found."
-					: `${chunks.length} related result${chunks.length === 1 ? "" : "s"}.`;
+					: `${renderedCount} related result${renderedCount === 1 ? "" : "s"}.`;
 		} catch (error) {
-			if (error instanceof DOMException && error.name === "AbortError") return;
+			if (
+				activeRequest !== controller ||
+				(error instanceof DOMException && error.name === "AbortError")
+			) {
+				return;
+			}
 			status.textContent =
 				"AI search is temporarily unavailable. Try conventional search instead.";
+		} finally {
+			if (activeRequest === controller) activeRequest = undefined;
 		}
 	}
 
@@ -151,7 +164,13 @@ function initializeAISearch(dialog: HTMLDialogElement) {
 		debounce = window.setTimeout(() => void search(query), SEARCH_DEBOUNCE_MS);
 	});
 
-	dialog.addEventListener("close", resetRequest);
+	dialog.addEventListener("close", () => {
+		resetRequest();
+		input.value = "";
+		fallback.href = "/";
+		results.replaceChildren();
+		status.textContent = "Enter at least two characters to search.";
+	});
 }
 
 document

--- a/src/js/ai-search-dialog.ts
+++ b/src/js/ai-search-dialog.ts
@@ -1,0 +1,159 @@
+interface AISearchChunk {
+	item: {
+		key: string;
+		metadata: {
+			title: string;
+			description?: string;
+		};
+	};
+}
+
+interface AISearchResponse {
+	success: boolean;
+	result?: {
+		chunks?: AISearchChunk[];
+	};
+}
+
+const SEARCH_DEBOUNCE_MS = 600;
+const SEARCH_RESULT_LIMIT = 8;
+const MINIMUM_QUERY_LENGTH = 2;
+
+function requiredElement<T extends Element>(
+	root: Document | HTMLDialogElement,
+	selector: string,
+): T {
+	const element = root.querySelector<T>(selector);
+	if (!element) throw new Error(`Missing AI search element: ${selector}`);
+	return element;
+}
+
+function resultUrl(value: string): URL | null {
+	try {
+		const url = new URL(value, window.location.origin);
+		return url.origin === window.location.origin ? url : null;
+	} catch {
+		return null;
+	}
+}
+
+function renderResults(container: HTMLOListElement, chunks: AISearchChunk[]) {
+	container.replaceChildren();
+
+	for (const chunk of chunks) {
+		const url = resultUrl(chunk.item.key);
+		if (!url) continue;
+
+		const item = document.createElement("li");
+		const link = document.createElement("a");
+		const title = document.createElement("strong");
+		const description = document.createElement("span");
+		const path = document.createElement("small");
+
+		link.href = `${url.pathname}${url.search}${url.hash}`;
+		title.textContent = chunk.item.metadata.title;
+		description.textContent = chunk.item.metadata.description ?? "";
+		path.textContent = url.pathname;
+
+		link.appendChild(title);
+		if (description.textContent) link.appendChild(description);
+		link.appendChild(path);
+		item.appendChild(link);
+		container.appendChild(item);
+	}
+}
+
+function initializeAISearch(dialog: HTMLDialogElement) {
+	if (dialog.dataset.aiSearchReady === "true") return;
+	dialog.dataset.aiSearchReady = "true";
+
+	const trigger = requiredElement<HTMLButtonElement>(
+		document,
+		`[data-ai-search-open][aria-controls="${dialog.id}"]`,
+	);
+	const input = requiredElement<HTMLInputElement>(
+		dialog,
+		"[data-ai-search-query]",
+	);
+	const status = requiredElement<HTMLElement>(
+		dialog,
+		"[data-ai-search-status]",
+	);
+	const results = requiredElement<HTMLOListElement>(
+		dialog,
+		"[data-ai-search-results]",
+	);
+	const fallback = requiredElement<HTMLAnchorElement>(
+		dialog,
+		"[data-ai-search-fallback]",
+	);
+	const apiUrl = dialog.dataset.apiUrl ?? "";
+	if (!apiUrl) throw new Error("Missing AI search API URL");
+
+	let debounce: number | undefined;
+	let activeRequest: AbortController | undefined;
+
+	function resetRequest() {
+		window.clearTimeout(debounce);
+		activeRequest?.abort();
+		activeRequest = undefined;
+	}
+
+	async function search(query: string) {
+		activeRequest = new AbortController();
+		status.textContent = "Searching...";
+		results.replaceChildren();
+
+		try {
+			const response = await fetch(apiUrl, {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					messages: [{ role: "user", content: query }],
+					ai_search_options: {
+						retrieval: { max_num_results: SEARCH_RESULT_LIMIT },
+					},
+				}),
+				signal: activeRequest.signal,
+			});
+			const body = (await response.json()) as AISearchResponse;
+			if (!response.ok || !body.success) throw new Error("AI search failed");
+
+			const chunks = body.result?.chunks ?? [];
+			renderResults(results, chunks);
+			status.textContent =
+				chunks.length === 0
+					? "No related content found."
+					: `${chunks.length} related result${chunks.length === 1 ? "" : "s"}.`;
+		} catch (error) {
+			if (error instanceof DOMException && error.name === "AbortError") return;
+			status.textContent =
+				"AI search is temporarily unavailable. Try conventional search instead.";
+		}
+	}
+
+	trigger.addEventListener("click", () => {
+		dialog.showModal();
+		input.focus();
+	});
+
+	input.addEventListener("input", () => {
+		resetRequest();
+		const query = input.value.trim();
+		fallback.href = query ? `/?s=${encodeURIComponent(query)}` : "/";
+
+		if (query.length < MINIMUM_QUERY_LENGTH) {
+			results.replaceChildren();
+			status.textContent = "Enter at least two characters to search.";
+			return;
+		}
+
+		debounce = window.setTimeout(() => void search(query), SEARCH_DEBOUNCE_MS);
+	});
+
+	dialog.addEventListener("close", resetRequest);
+}
+
+document
+	.querySelectorAll<HTMLDialogElement>("[data-ai-search-dialog]")
+	.forEach(initializeAISearch);

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -6,4 +6,5 @@ import "bootstrap/js/dist/dropdown";
 import "bootstrap-icons/font/bootstrap-icons.css";
 
 // Import custom JavaScript modules
+import "./ai-search-dialog";
 import "./emdash-save-gate.js";

--- a/src/pages/api/ai-search/search.ts
+++ b/src/pages/api/ai-search/search.ts
@@ -1,0 +1,1 @@
+export { POST, prerender } from "@emdash-cms/cloudflare/plugins/ai-search";

--- a/src/scss/_navigation.scss
+++ b/src/scss/_navigation.scss
@@ -40,6 +40,88 @@
 	height: auto;
 }
 
+.ai-search-dialog {
+	width: min(42rem, calc(100% - 2rem));
+	max-height: 80vh;
+	padding: 0;
+	border: 1px solid $gray-500;
+	border-radius: 0.25rem;
+	box-shadow: 0 1rem 3rem rgb(0 0 0 / 25%);
+}
+
+.ai-search-dialog::backdrop {
+	background: rgb(0 0 0 / 55%);
+}
+
+.ai-search-dialog__panel {
+	display: flex;
+	max-height: inherit;
+	flex-direction: column;
+	background: $white;
+}
+
+.ai-search-dialog__header,
+.ai-search-dialog__footer {
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: 1rem;
+	padding: 1rem 1.25rem;
+}
+
+.ai-search-dialog__header {
+	border-bottom: 1px solid $gray-300;
+}
+
+.ai-search-dialog__header p,
+.ai-search-dialog__status,
+.ai-search-dialog__results small {
+	color: $gray-600;
+}
+
+.ai-search-dialog__body {
+	overflow-y: auto;
+	padding: 1.25rem;
+}
+
+.ai-search-dialog__status {
+	min-height: 1.5rem;
+	margin: 0.75rem 0;
+}
+
+.ai-search-dialog__results {
+	display: grid;
+	gap: 0.75rem;
+	padding: 0;
+	margin: 0;
+	list-style: none;
+}
+
+.ai-search-dialog__results a {
+	display: grid;
+	gap: 0.2rem;
+	padding: 0.75rem;
+	color: $body-color;
+	text-decoration: none;
+	border: 1px solid $gray-300;
+	border-radius: 0.25rem;
+}
+
+.ai-search-dialog__results a:hover,
+.ai-search-dialog__results a:focus-visible {
+	border-color: $orange;
+	box-shadow: 0 0 0 0.2rem rgb(253 126 20 / 20%);
+}
+
+.ai-search-dialog__results strong {
+	color: $orange;
+}
+
+.ai-search-dialog__footer {
+	justify-content: flex-end;
+	border-top: 1px solid $gray-300;
+}
+
 // Menu alert
 #menu-alert {
 	margin: 4px 0 0;

--- a/tests/unit/plugins/plugin-registration.test.ts
+++ b/tests/unit/plugins/plugin-registration.test.ts
@@ -55,4 +55,21 @@ describe("EmDash plugin registration", () => {
 			capabilities: ["content:read"],
 		});
 	});
+
+	test("registers AI Search with compatibility result routes", () => {
+		const plugin = emdashPlugins.find(({ id }) => id === "ai-search");
+
+		expect(plugin).toMatchObject({
+			entrypoint: "@emdash-cms/cloudflare/plugins/ai-search",
+			capabilities: ["read:content"],
+			options: {
+				instanceName: "engaged-philosophy",
+				urlTemplates: {
+					pages: "/pages/{slug}",
+					posts: "/posts/{slug}",
+					projects: "/project/{slug}",
+				},
+			},
+		});
+	});
 });

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -55,6 +55,12 @@
 			"bucket_name": "engaged-philosophy-media",
 		},
 	],
+	"ai_search_namespaces": [
+		{
+			"binding": "AI_SEARCH",
+			"namespace": "default",
+		},
+	],
 	"env": {
 		"production": {
 			"name": "engaged-philosophy",
@@ -75,6 +81,12 @@
 				{
 					"binding": "MEDIA",
 					"bucket_name": "engaged-philosophy-media",
+				},
+			],
+			"ai_search_namespaces": [
+				{
+					"binding": "AI_SEARCH",
+					"namespace": "default",
 				},
 			],
 		},


### PR DESCRIPTION
## Summary

- register the EmDash 0.32 Cloudflare AI Search plugin for pages, posts, and projects
- bind the Worker to the account default AI Search namespace and use a site-specific instance name
- expose the standard EmDash public search endpoint
- add a reversible AI Search dialog while retaining conventional EmDash full-text search
- document initial indexing, preview cron behavior, and the Workers Free limits

EmDash still owns the AI Search instance, admin controls, full and incremental
indexing, URL generation, and endpoint. The small public dialog is site code
because the upstream snippet injects inline styles that the public Content
Security Policy rejects.

## Testing

- `pnpm run ci`
- `pnpm exec wrangler deploy --dry-run --env production`
- focused AI Search browser coverage verifies the request, safe result
  rendering/counts, state reset, fallback, dialog behavior, strict-CSP
  baseline, and mobile viewport fit
- the real EmDash endpoint returned eight valid results for both `philosophy`
  and `pacific` against the shared Cloudflare index

The local browser test mocks the managed Cloudflare response; the deployed
preview exercises the real binding and index.

## Preview setup

The shared pilot index is currently primed with all 76 posts and 31 pages, with
zero upload errors. Suggested queries include `philosophy`, `pacific`,
`environmental justice`, `community partnerships`, and
`philosophy in prisons`.

Cloudflare branch previews do not receive Cron Trigger events. Starting **Sync
All Content** from a preview queues the EmDash job but does not advance it
without a maintainer manually invoking that branch's scheduled handler against
the remote bindings. Once merged, the production cron processes sync jobs
normally. Preview and production use the same `engaged-philosophy` instance
in the `default` namespace, so the existing index is reused after promotion.

Projects were not selected in the pilot sync and remain unindexed. They can be
selected and synced after merge, or in the preview followed by another manual
scheduled-handler run.

## Free plan

Cloudflare currently allows 20,000 AI Search queries per month and 100,000 files
per instance on Workers Free during the open beta. The UI debounces input,
limits each request to eight results, and falls back cleanly if AI Search is
unavailable. The pilot keeps the standard EmDash endpoint unwrapped; usage
should be observed before adding custom rate-limiting code.
