### PR TITLE
fix: restore audit log hooks

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -52,8 +52,13 @@ function localEmDashRoutes() {
 	};
 }
 
+export const configuredAuditLogPlugin = {
+	...auditLogPlugin,
+	capabilities: ["content:read", "content:write", "media:read"],
+};
+
 export const emdashPlugins = [
-	auditLogPlugin,
+	configuredAuditLogPlugin,
 	embedsPlugin({ types: ["youtube", "vimeo"] }),
 	{
 		id: "legacy-image-blocks",

--- a/docs/emdash-customizations.md
+++ b/docs/emdash-customizations.md
@@ -164,11 +164,13 @@ other required values, the route fails closed with `ACCESS_CONFIG_ERROR`.
 
 ## Plugins
 
-- The upstream audit-log descriptor is registered directly. EmDash adapts its
-  standard-format entrypoint for trusted in-process execution, so it works
-  without Dynamic Worker loaders on the current Cloudflare plan. EmDash 0.33
-  also materializes the plugin's storage index instead of scanning the audit
-  table for dashboard queries.
+- The upstream audit-log descriptor runs through EmDash's standard-format
+  adapter for trusted in-process execution, so it works without Dynamic Worker
+  loaders on the current Cloudflare plan. Audit-log 0.2.0 under-declares the
+  capabilities required by its hooks, so `astro.config.mjs` adds
+  `content:write` and `media:read`; otherwise EmDash skips the before-save
+  snapshot and media-upload hooks. EmDash 0.33 also materializes the plugin's
+  storage index instead of scanning the audit table for dashboard queries.
 - The upstream embeds plugin registers and renders the enabled YouTube and Vimeo
   blocks directly.
 - `src/plugins/legacy-content-blocks.ts` preserves edit controls for imported
@@ -191,6 +193,13 @@ other required values, the route fails closed with `ACCESS_CONFIG_ERROR`.
 
 ## Removal Candidates
 
+- Remove the audit-log capability override when a published
+  `@emdash-cms/plugin-audit-log` descriptor includes both `content:write` and
+  `media:read` (the fix tracked by
+  [EmDash #1263](https://github.com/emdash-cms/emdash/issues/1263) and
+  [PR #1897](https://github.com/emdash-cms/emdash/pull/1897)). Restore direct
+  descriptor registration and keep the hook-registration test to confirm
+  EmDash no longer skips either hook.
 - Revisit the visual-editing save gate when the upstream toolbar explicitly
   waits for Portable Text saves before publishing or leaving edit mode.
 - Remove the local cache-provider wrapper when Wrangler exposes

--- a/tests/unit/plugins/plugin-registration.test.ts
+++ b/tests/unit/plugins/plugin-registration.test.ts
@@ -1,8 +1,13 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 
 import auditLogPlugin from "@emdash-cms/plugin-audit-log";
+import auditLogDefinition from "@emdash-cms/plugin-audit-log/sandbox";
+import { adaptSandboxEntry, HookPipeline } from "emdash";
 
-import { emdashPlugins } from "../../../astro.config.mjs";
+import {
+	configuredAuditLogPlugin,
+	emdashPlugins,
+} from "../../../astro.config.mjs";
 
 import { createPlugin as createLegacyContentPlugin } from "../../../src/plugins/legacy-content-blocks";
 
@@ -45,14 +50,30 @@ describe("EmDash plugin registration", () => {
 		});
 	});
 
-	test("registers the standard audit log plugin directly", () => {
-		const plugin = emdashPlugins.find(({ id }) => id === "audit-log");
+	test("grants the capabilities required by the audit log hooks", () => {
+		const plugin = configuredAuditLogPlugin;
 
-		expect(plugin).toBe(auditLogPlugin);
+		expect(emdashPlugins).toContain(plugin);
+		expect(plugin).not.toBe(auditLogPlugin);
 		expect(plugin).toMatchObject({
 			format: "standard",
 			entrypoint: "@emdash-cms/plugin-audit-log/sandbox",
-			capabilities: ["content:read"],
+			capabilities: ["content:read", "content:write", "media:read"],
 		});
+
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		try {
+			const resolved = adaptSandboxEntry(auditLogDefinition, plugin);
+			const hooks = new HookPipeline([resolved]).getRegisteredHooks();
+
+			expect(hooks).toEqual(
+				expect.arrayContaining(["content:beforeSave", "media:afterUpload"]),
+			);
+			expect(warn).not.toHaveBeenCalledWith(
+				expect.stringContaining('Plugin "audit-log" declares'),
+			);
+		} finally {
+			warn.mockRestore();
+		}
 	});
 });


### PR DESCRIPTION
## Summary

- overlay the published audit-log descriptor with the `content:write` and `media:read` capabilities required by its registered hooks
- verify the real packaged audit-log definition through EmDash HookPipeline so `content:beforeSave` and `media:afterUpload` cannot be silently skipped
- document the upstream bug and the exact condition for removing the workaround

## Impact

`@emdash-cms/plugin-audit-log@0.2.0` declares only `content:read`. EmDash therefore skips two hooks during startup:

- `content:beforeSave`, which captures the previous content snapshot used for update diffs
- `media:afterUpload`, which records media-upload audit entries

The override matches the proposed upstream fix and restores both hooks.

## Removal

Remove the override after a published `@emdash-cms/plugin-audit-log` descriptor includes both `content:write` and `media:read`, tracked by [EmDash #1263](https://github.com/emdash-cms/emdash/issues/1263) and [upstream PR #1897](https://github.com/emdash-cms/emdash/pull/1897). At that point, restore direct descriptor registration while retaining the hook-pipeline regression assertion.

## Testing

- `pnpm run ci`
  - 99 unit tests
  - 6 static-browser tests
  - Astro and TypeScript checks
  - production Worker build
  - Worker bundle and runtime smoke tests
  - 37 Worker-backed Playwright tests

## Screenshots

Not applicable; this changes plugin hook registration and audit completeness without altering the UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced audit logging with content read/write and media read capabilities.
  * Audit-log hooks now register without capability warnings.
* **Documentation**
  * Updated customization guidance to describe the enabled capabilities and configuration behavior.
  * Added guidance for removing the customization when equivalent upstream support is available.
* **Tests**
  * Expanded coverage to verify audit-log capabilities, hook registration, and warning-free setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->